### PR TITLE
Add arm64 builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64
+        # build and publish in parallel: linux/386, linux/amd64, linux/arm64, windows/386, windows/amd64, windows/arm64, darwin/amd64, darwin/arm64
         goos: [linux, windows, darwin]
         goarch: ["386", "amd64", "arm64"]
         exclude:  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64 
+        # build and publish in parallel: linux/386, linux/amd64, windows/386, windows/amd64, darwin/amd64
         goos: [linux, windows, darwin]
-        goarch: ["386", amd64]
+        goarch: ["386", "amd64", "arm64"]
         exclude:  
           - goarch: "386"
             goos: darwin 


### PR DESCRIPTION
Pretty much what it says on the tin, especially with AWS Graviton becoming more popular (which is what we would be interested in using this for).

Happy to close if there's no interest, I didn't see any contribution guide.

Thanks for writing this!