### PR TITLE
Adding Copyrights header to the code source

### DIFF
--- a/backend/akeyless/session.go
+++ b/backend/akeyless/session.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package akeyless
 
 import (

--- a/backend/akeyless/vault.go
+++ b/backend/akeyless/vault.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package akeyless
 
 import (

--- a/backend/aws/secrets.go
+++ b/backend/aws/secrets.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package aws
 
 import (

--- a/backend/aws/session.go
+++ b/backend/aws/session.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package aws
 
 import (

--- a/backend/aws/ssm.go
+++ b/backend/aws/ssm.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package aws
 
 import (

--- a/backend/azure/keyvault.go
+++ b/backend/azure/keyvault.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package azure
 
 import (

--- a/backend/azure/session.go
+++ b/backend/azure/session.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package azure
 
 import (

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package backend
 
 import (

--- a/backend/error.go
+++ b/backend/error.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package backend
 
 import "github.com/rapdev-io/datadog-secret-backend/secret"

--- a/backend/file/json.go
+++ b/backend/file/json.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package file
 
 import (

--- a/backend/file/yaml.go
+++ b/backend/file/yaml.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package file
 
 import (

--- a/backend/hashicorp/session.go
+++ b/backend/hashicorp/session.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package hashicorp
 
 import (

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package hashicorp
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package main
 
 import (

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -1,3 +1,9 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
 package secret
 
 type SecretOutput struct {


### PR DESCRIPTION
This commit import tooling from https://github.com/DataDog/datadog-agent repo to automatically scan and add copyrights header to all the code source.