### PR TITLE
Add default Datadog codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @DataDog/agent-shared-components


### PR DESCRIPTION
This will ensure that the proper code reviewers are auto-assigned when PRs are opened