### PR TITLE
Update import paths to point to the new repo org

### DIFF
--- a/backend/akeyless/vault.go
+++ b/backend/akeyless/vault.go
@@ -10,8 +10,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"github.com/DataDog/datadog-secret-backend/secret"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rapdev-io/datadog-secret-backend/secret"
 	"github.com/rs/zerolog/log"
 	"net/http"
 )

--- a/backend/aws/secrets.go
+++ b/backend/aws/secrets.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 
-	"github.com/rapdev-io/datadog-secret-backend/secret"
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 type AwsSecretsManagerBackendConfig struct {

--- a/backend/aws/ssm.go
+++ b/backend/aws/ssm.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 
-	"github.com/rapdev-io/datadog-secret-backend/secret"
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 type AwsSsmParameterStoreBackendConfig struct {

--- a/backend/azure/keyvault.go
+++ b/backend/azure/keyvault.go
@@ -11,8 +11,8 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/v7.1/keyvault"
+	"github.com/DataDog/datadog-secret-backend/secret"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rapdev-io/datadog-secret-backend/secret"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -8,18 +8,18 @@ package backend
 
 import (
 	"fmt"
-	"github.com/rapdev-io/datadog-secret-backend/backend/akeyless"
-	"github.com/rapdev-io/datadog-secret-backend/backend/hashicorp"
 	"io/ioutil"
 	"strings"
 
 	"github.com/rs/zerolog/log"
 	"gopkg.in/yaml.v2"
 
-	"github.com/rapdev-io/datadog-secret-backend/backend/aws"
-	"github.com/rapdev-io/datadog-secret-backend/backend/azure"
-	"github.com/rapdev-io/datadog-secret-backend/backend/file"
-	"github.com/rapdev-io/datadog-secret-backend/secret"
+	"github.com/DataDog/datadog-secret-backend/backend/akeyless"
+	"github.com/DataDog/datadog-secret-backend/backend/aws"
+	"github.com/DataDog/datadog-secret-backend/backend/azure"
+	"github.com/DataDog/datadog-secret-backend/backend/file"
+	"github.com/DataDog/datadog-secret-backend/backend/hashicorp"
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 type Backend interface {

--- a/backend/error.go
+++ b/backend/error.go
@@ -6,7 +6,7 @@
 
 package backend
 
-import "github.com/rapdev-io/datadog-secret-backend/secret"
+import "github.com/DataDog/datadog-secret-backend/secret"
 
 type ErrorBackend struct {
 	BackendId string

--- a/backend/file/json.go
+++ b/backend/file/json.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 
-	"github.com/rapdev-io/datadog-secret-backend/secret"
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 type FileJsonBackendConfig struct {

--- a/backend/file/yaml.go
+++ b/backend/file/yaml.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/rs/zerolog/log"
 
-	"github.com/rapdev-io/datadog-secret-backend/secret"
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 type FileYamlBackendConfig struct {

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -9,9 +9,9 @@ package hashicorp
 import (
 	"context"
 	"errors"
+	"github.com/DataDog/datadog-secret-backend/secret"
 	"github.com/hashicorp/vault/api"
 	"github.com/mitchellh/mapstructure"
-	"github.com/rapdev-io/datadog-secret-backend/secret"
 	"github.com/rs/zerolog/log"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
-module github.com/rapdev-io/datadog-secret-backend
+module github.com/DataDog/datadog-secret-backend
 
 go 1.17
 
 replace (
-	github.com/rapdev-io/datadog-secret-backend/backend => ./backend
-	github.com/rapdev-io/datadog-secret-backend/backend/aws => ./backend/aws
-	github.com/rapdev-io/datadog-secret-backend/backend/aws/secretsmanager => ./backend/aws/secretsmanager
+	github.com/DataDog/datadog-secret-backend/backend => ./backend
+	github.com/DataDog/datadog-secret-backend/backend/aws => ./backend/aws
+	github.com/DataDog/datadog-secret-backend/backend/aws/secretsmanager => ./backend/aws/secretsmanager
 )
 
 require (

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 
-	"github.com/rapdev-io/datadog-secret-backend/backend"
+	"github.com/DataDog/datadog-secret-backend/backend"
 )
 
 type InputPayload struct {


### PR DESCRIPTION
This change ensures that Go dependencies are using the new org as the canonical source.