### PR TITLE
[cli] Clean up version flag handling

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,25 +45,19 @@ func init() {
 	log.Logger = zerolog.New(output).With().Timestamp().Logger()
 }
 
-func printVersion() {
-	fmt.Fprintf(os.Stdout, "%s: v%s\n", filepath.Base(os.Args[0]), appVersion)
-	os.Exit(0)
-}
-
 func main() {
 	program, _ := os.Executable()
 	programPath := filepath.Dir(program)
 	defaultConfigFile := filepath.Join(programPath, "datadog-secret-backend.yaml")
 
-	version := flag.Bool("version", false,
-		fmt.Sprintf("Print the version info"),
-	)
+	version := flag.Bool("version", false, fmt.Sprintf("Print the version info"))
 	configFile := flag.String("config", defaultConfigFile, "Path to backend configuration yaml")
 
 	flag.Parse()
 
 	if *version {
-		printVersion()
+		fmt.Fprintf(os.Stdout, "%s v%s\n", filepath.Base(program), appVersion)
+		os.Exit(0)
 	}
 
 	input, err := ioutil.ReadAll(os.Stdin)

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func init() {
 }
 
 func printVersion() {
-	fmt.Fprintf(os.Stdout, "%s: v%s\n\nRapDev (https://www.rapdev.io) (c) 2021\n",
+	fmt.Fprintf(os.Stdout, "%s: v%s\n",
 		filepath.Base(os.Args[0]), appVersion)
 	os.Exit(0)
 }

--- a/main.go
+++ b/main.go
@@ -46,8 +46,7 @@ func init() {
 }
 
 func printVersion() {
-	fmt.Fprintf(os.Stdout, "%s: v%s\n",
-		filepath.Base(os.Args[0]), appVersion)
+	fmt.Fprintf(os.Stdout, "%s: v%s\n", filepath.Base(os.Args[0]), appVersion)
 	os.Exit(0)
 }
 
@@ -57,7 +56,7 @@ func main() {
 	defaultConfigFile := filepath.Join(programPath, "datadog-secret-backend.yaml")
 
 	version := flag.Bool("version", false,
-		fmt.Sprintf("Displays version and information of %s", filepath.Base(program)),
+		fmt.Sprintf("Print the version info"),
 	)
 	configFile := flag.String("config", defaultConfigFile, "Path to backend configuration yaml")
 


### PR DESCRIPTION
### What does this PR do?

Improves handling of the version info from the CLI. Version handling inlined.

### Motivation

Make the version print out be minimal

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

- Build
- Run `datadog-secret-backend --version`