### PR TITLE
[backend] Fix panic when secret ID is malformatted

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@
 
 Reference each supported backend type's documentation on specific usage examples and configuration options.
 
+## Running tests
+
+You can run the tests with the following command:
+
+```bash
+go test ./...
+```
+
 ## License
 
 [BSD-3-Clause License](LICENSE)

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -136,11 +136,16 @@ func (b *Backends) InitBackend(backendId string, config map[string]interface{}) 
 	return
 }
 
-func (b *Backends) GetSecretOutputs(secrets []string) map[string]secret.SecretOutput {
+func (b *Backends) GetSecretOutputs(secrets []string) (map[string]secret.SecretOutput, error) {
 	secretOutputs := make(map[string]secret.SecretOutput, 0)
 
 	for _, s := range secrets {
 		segments := strings.SplitN(s, ":", 2)
+		if len(segments) < 2 {
+			return nil,
+				fmt.Errorf("secret '%s' is not in the expected '<backend>:<id>' format", s)
+		}
+
 		backendId := segments[0]
 		secretKey := segments[1]
 
@@ -155,5 +160,5 @@ func (b *Backends) GetSecretOutputs(secrets []string) map[string]secret.SecretOu
 		}
 		secretOutputs[s] = b.Backends[backendId].GetSecretOutput(secretKey)
 	}
-	return secretOutputs
+	return secretOutputs, nil
 }

--- a/backend/backend_test.go
+++ b/backend/backend_test.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+
+package backend
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSecretsOutputWithMissingBackend(t *testing.T) {
+	// Ensure that we don't panic
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("Code panic in TestGetSecretsOutputWithMissingBackend!")
+		}
+	}()
+
+	backends := Backends{
+		Backends: make(map[string]Backend, 0),
+	}
+
+	_, err := backends.GetSecretOutputs([]string{"foo", "bar"})
+	require.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/rs/zerolog v1.32.0
 	github.com/sirupsen/logrus v1.9.3
+	github.com/stretchr/testify v1.8.4
 	gopkg.in/yaml.v2 v2.4.0
 )
 
@@ -79,4 +80,5 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -78,7 +78,10 @@ func main() {
 	}
 
 	backends := backend.NewBackends(configFile)
-	secretOutputs := backends.GetSecretOutputs(inputPayload.Secrets)
+	secretOutputs, err := backends.GetSecretOutputs(inputPayload.Secrets)
+	if err != nil {
+		log.Fatal().Err(err).Msg("failed to resolve secrets")
+	}
 
 	output, err := json.Marshal(secretOutputs)
 	if err != nil {


### PR DESCRIPTION


### What does this PR do?

Fixes a panic hen processing secret IDs in unexpected format (e.g. with missing backend). Also adds the first test to the repo.

### Motivation

Code had panics when secret did not have the expected `<backend>:<id>` format. This change ensures that we now return a proper error to the user if there's no `:`.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Following should not panic (make sure to have an empty config file though):
```
 echo '{"version": "1.0", "secrets": ["secret1", "secret2"]}' | ./datadog-secret-backend -config -config <empty config file>
```

Also

`go test ./...`
