### PR TITLE
[AGENTCFG-307] Removing secret_id from the AWS Secrets Config and parameters/parameters_path from the AWS SSM Config

### DIFF
--- a/backend/aws/secrets.go
+++ b/backend/aws/secrets.go
@@ -101,15 +101,16 @@ func NewSecretsManagerBackend(bc map[string]interface{}, bs []string) (
 }
 
 // GetSecretOutput returns a the value for a specific secret
-func (b *SecretsManagerBackend) GetSecretOutput(secretKey string) secret.Output {
-	if val, ok := b.Secret[secretKey]; ok {
+func (b *SecretsManagerBackend) GetSecretOutput(secretString string) secret.Output {
+	segments := strings.SplitN(secretString, ";", 2)
+	if val, ok := b.Secret[segments[1]]; ok {
 		return secret.Output{Value: &val, Error: nil}
 	}
 	es := secret.ErrKeyNotFound.Error()
 
 	log.Error().
 		Str("backend_type", b.Config.BackendType).
-		Str("secret_key", secretKey).
+		Str("secret_key", segments[1]).
 		Msg(es)
 	return secret.Output{Value: nil, Error: &es}
 }

--- a/backend/aws/secrets.go
+++ b/backend/aws/secrets.go
@@ -67,7 +67,6 @@ func NewSecretsManagerBackend(bc map[string]interface{}, bs []string) (
 	}
 	client := getSecretsManagerClient(*cfg)
 
-	// GetSecretValue
 	secretValue := make(map[string]string, 0)
 	for _, s := range bs {
 		segments := strings.SplitN(s, ";", 2)
@@ -110,7 +109,6 @@ func (b *SecretsManagerBackend) GetSecretOutput(secretKey string) secret.Output 
 
 	log.Error().
 		Str("backend_type", b.Config.BackendType).
-		Str("secret_id", b.Config.SecretID).
 		Str("secret_key", secretKey).
 		Msg(es)
 	return secret.Output{Value: nil, Error: &es}

--- a/backend/aws/secrets_test.go
+++ b/backend/aws/secrets_test.go
@@ -8,7 +8,6 @@ package aws
 
 import (
 	"context"
-	"strings"
 	"testing"
 
 	"github.com/DataDog/datadog-secret-backend/secret"
@@ -20,31 +19,29 @@ import (
 // secretsManagerMockClient is the struct we'll use to mock the Secrets Manager client
 // for unit tests. E2E tests should be written with the real client.
 type secretsManagerMockClient struct {
-	secrets map[string]interface{}
+	secrets map[string]string
 }
 
 func (c *secretsManagerMockClient) GetSecretValue(_ context.Context, params *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
 	if params == nil || params.SecretId == nil {
-		return nil, nil
+		return nil, secret.ErrKeyNotFound
 	}
 
-	for key, value := range c.secrets {
-		segments := strings.SplitN(key, ";", 2)
-		if len(segments) == 2 && segments[1] == *params.SecretId {
-			return &secretsmanager.GetSecretValueOutput{
-				Name:         aws.String(segments[1]),
-				SecretString: aws.String(value.(string)),
-			}, nil
-		}
+	if secretValue, exists := c.secrets[*params.SecretId]; exists {
+		return &secretsmanager.GetSecretValueOutput{
+			Name:         aws.String(*params.SecretId),
+			SecretString: aws.String(secretValue),
+		}, nil
 	}
+
 	return nil, secret.ErrKeyNotFound
 }
 
 func TestSecretsManagerBackend(t *testing.T) {
 	mockClient := &secretsManagerMockClient{
-		secrets: map[string]interface{}{
-			"something1;key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
-			"something2;key2": "{\"foo\":\"bar\"}",
+		secrets: map[string]string{
+			"key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
+			"key2": "{\"foo\":\"bar\"}",
 		},
 	}
 	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
@@ -55,8 +52,7 @@ func TestSecretsManagerBackend(t *testing.T) {
 		"backend_type": "aws.secrets",
 		"force_string": false,
 	}
-	secretsManagerBackendSecrets := []string{"key1;user", "key1;password"}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, secretsManagerSecretsBackend)
 
@@ -78,9 +74,9 @@ func TestSecretsManagerBackend(t *testing.T) {
 
 func TestSecretsManagerBackend_ForceString(t *testing.T) {
 	mockClient := &secretsManagerMockClient{
-		secrets: map[string]interface{}{
-			"something1;key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
-			"something2;key2": "{\"foo\":\"bar\"}",
+		secrets: map[string]string{
+			"key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
+			"key2": "{\"foo\":\"bar\"}",
 		},
 	}
 	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
@@ -91,8 +87,7 @@ func TestSecretsManagerBackend_ForceString(t *testing.T) {
 		"backend_type": "aws.secrets",
 		"force_string": true,
 	}
-	secretsManagerBackendSecrets := []string{"key1;user", "key1;password"}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
 	assert.NoError(t, err)
 	assert.NotNil(t, secretsManagerSecretsBackend)
 
@@ -104,9 +99,9 @@ func TestSecretsManagerBackend_ForceString(t *testing.T) {
 
 func TestSecretsManagerBackend_NotJSON(t *testing.T) {
 	mockClient := &secretsManagerMockClient{
-		secrets: map[string]interface{}{
-			"something1;key1": "not json",
-			"something2;key2": "foobar",
+		secrets: map[string]string{
+			"key1": "not json",
+			"key2": "foobar",
 		},
 	}
 	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
@@ -117,16 +112,65 @@ func TestSecretsManagerBackend_NotJSON(t *testing.T) {
 		"backend_type": "aws.secrets",
 		"force_string": false,
 	}
-	secretsManagerBackendSecrets := []string{"key1;value1", "key2;value2"}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
 	assert.NoError(t, err)
 
-	// Top-level keys are not fetchable
-	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("something1;key1")
-	assert.Nil(t, secretOutput.Value)
-	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
+	// When the secret value is not JSON, it should be returned as-is
+	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("key1;anything")
+	assert.NotNil(t, secretOutput.Value)
+	assert.Equal(t, "not json", *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
 
-	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("something2;key2")
+	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key2;anything")
+	assert.NotNil(t, secretOutput.Value)
+	assert.Equal(t, "foobar", *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
+}
+
+func TestSecretsManagerBackend_InvalidFormat(t *testing.T) {
+	mockClient := &secretsManagerMockClient{
+		secrets: map[string]string{
+			"key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
+		},
+	}
+	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
+		return mockClient
+	}
+
+	secretsManagerBackendParams := map[string]interface{}{
+		"backend_type": "aws.secrets",
+		"force_string": false,
+	}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	assert.NoError(t, err)
+
+	// Test invalid secret format (missing semicolon)
+	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("key1")
 	assert.Nil(t, secretOutput.Value)
+	assert.NotNil(t, secretOutput.Error)
+	assert.Equal(t, "invalid secret format, expected 'secret_id;key'", *secretOutput.Error)
+}
+
+func TestSecretsManagerBackend_SecretNotFound(t *testing.T) {
+	mockClient := &secretsManagerMockClient{
+		secrets: map[string]string{
+			"key1": "{\"user\":\"foo\",\"password\":\"bar\"}",
+		},
+	}
+	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
+		return mockClient
+	}
+
+	secretsManagerBackendParams := map[string]interface{}{
+		"backend_type": "aws.secrets",
+		"force_string": false,
+	}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	assert.NoError(t, err)
+
+	// Test secret ID that doesn't exist
+	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("nonexistent;user")
+	assert.Nil(t, secretOutput.Value)
+	assert.NotNil(t, secretOutput.Error)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }

--- a/backend/aws/secrets_test.go
+++ b/backend/aws/secrets_test.go
@@ -51,10 +51,10 @@ func TestSecretsManagerBackend(t *testing.T) {
 
 	secretsManagerBackendParams := map[string]interface{}{
 		"backend_type": "aws.secrets",
-		"secret_id":    "key1",
 		"force_string": false,
 	}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	secretsManagerBackendSecrets := []string{"key1;user", "key1;password"}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
 	assert.NoError(t, err)
 
 	// Top-level keys are not fetchable
@@ -92,14 +92,11 @@ func TestSecretsManagerBackend_ForceString(t *testing.T) {
 		"secret_id":    "key1",
 		"force_string": true,
 	}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	secretsManagerBackendSecrets := []string{"key1;user", "key1;password"}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
 	assert.NoError(t, err)
 
-	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("_")
-	assert.Equal(t, "{\"user\":\"foo\",\"password\":\"bar\"}", *secretOutput.Value)
-	assert.Nil(t, secretOutput.Error)
-
-	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key1")
+	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("key1")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }
@@ -120,7 +117,8 @@ func TestSecretsManagerBackend_NotJSON(t *testing.T) {
 		"secret_id":    "key1",
 		"force_string": false,
 	}
-	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	secretsManagerBackendSecrets := []string{"key1;user", "key1;password"}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams, secretsManagerBackendSecrets)
 	assert.NoError(t, err)
 
 	// Top-level keys are not fetchable
@@ -131,9 +129,4 @@ func TestSecretsManagerBackend_NotJSON(t *testing.T) {
 	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key2")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
-
-	// But the contents under the selected key are
-	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("_")
-	assert.Equal(t, "not json", *secretOutput.Value)
-	assert.Nil(t, secretOutput.Error)
 }

--- a/backend/aws/ssm.go
+++ b/backend/aws/ssm.go
@@ -8,7 +8,6 @@ package aws
 
 import (
 	"context"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ssm"
@@ -67,10 +66,9 @@ func NewSSMParameterStoreBackend(bc map[string]interface{}, bs []string) (
 	}
 	client := getSSMClient(*cfg)
 
-	for _, s := range bs {
-		segments := strings.SplitN(s, ";", 2)
+	for _, secretPath := range bs {
 		input := &ssm.GetParametersByPathInput{
-			Path:           &segments[1],
+			Path:           &secretPath,
 			Recursive:      aws.Bool(true),
 			WithDecryption: aws.Bool(true),
 		}
@@ -81,7 +79,7 @@ func NewSSMParameterStoreBackend(bc map[string]interface{}, bs []string) (
 			if err != nil {
 				log.Error().Err(err).
 					Str("backend_type", backendConfig.BackendType).
-					Str("parameter_path", segments[1]).
+					Str("parameter_path", secretPath).
 					Str("aws_access_key_id", backendConfig.Session.AccessKeyID).
 					Str("aws_profile", backendConfig.Session.Profile).
 					Str("aws_region", backendConfig.Session.Region).

--- a/backend/aws/ssm_test.go
+++ b/backend/aws/ssm_test.go
@@ -77,7 +77,7 @@ func TestSSMParameterStoreBackend_ParametersByPath(t *testing.T) {
 	ssmParameterStoreBackendParams := map[string]interface{}{
 		"backend_type": "aws.ssm",
 	}
-	ssmParameterStoreBackendSecrets := []string{";/group1/key1", ";/group1/nest/key2", ";/group2/key3"}
+	ssmParameterStoreBackendSecrets := []string{"/group1/key1", "/group1/nest/key2", "/group2/key3"}
 	ssmParameterStoreSecretsBackend, err := NewSSMParameterStoreBackend(ssmParameterStoreBackendParams, ssmParameterStoreBackendSecrets)
 	assert.NoError(t, err)
 

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -29,18 +29,18 @@ type GenericConnector struct {
 }
 
 // InitBackend initialize the backend based on their configuration
-func (g *GenericConnector) InitBackend(backendType string, backendConfig map[string]interface{}, backendSecrets []string) {
+func (g *GenericConnector) InitBackend(backendType string, backendConfig map[string]interface{}) {
 	backendConfig["backend_type"] = backendType
 	switch backendType {
 	case "aws.secrets":
-		backend, err := aws.NewSecretsManagerBackend(backendConfig, backendSecrets)
+		backend, err := aws.NewSecretsManagerBackend(backendConfig)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {
 			g.Backend = backend
 		}
 	case "aws.ssm":
-		backend, err := aws.NewSSMParameterStoreBackend(backendConfig, backendSecrets)
+		backend, err := aws.NewSSMParameterStoreBackend(backendConfig, nil)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {
@@ -54,7 +54,7 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 			g.Backend = backend
 		}
 	case "hashicorp.vault":
-		backend, err := hashicorp.NewVaultBackend(backendConfig, backendSecrets)
+		backend, err := hashicorp.NewVaultBackend(backendConfig, nil)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,6 +9,7 @@ package backend
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-secret-backend/backend/akeyless"
 	"github.com/DataDog/datadog-secret-backend/backend/aws"
@@ -33,7 +34,7 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 	backendConfig["backend_type"] = backendType
 	switch backendType {
 	case "aws.secrets":
-		backend, err := aws.NewSecretsManagerBackend(backendConfig)
+		backend, err := aws.NewSecretsManagerBackend(backendConfig, backendSecrets)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {
@@ -91,8 +92,9 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 // GetSecretOutputs returns a the value for a list of given secrets of form "<secret key>"
 func (g *GenericConnector) GetSecretOutputs(secrets []string) map[string]secret.Output {
 	secretOutputs := make(map[string]secret.Output, 0)
-	for _, secretKey := range secrets {
-		secretOutputs[secretKey] = g.Backend.GetSecretOutput(secretKey)
+	for _, s := range secrets {
+		segments := strings.SplitN(s, ";", 2)
+		secretOutputs[segments[1]] = g.Backend.GetSecretOutput(segments[1])
 	}
 	return secretOutputs
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -41,7 +41,7 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 			g.Backend = backend
 		}
 	case "aws.ssm":
-		backend, err := aws.NewSSMParameterStoreBackend(backendConfig)
+		backend, err := aws.NewSSMParameterStoreBackend(backendConfig, backendSecrets)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -92,9 +92,9 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 // GetSecretOutputs returns a the value for a list of given secrets of form "<secret key>"
 func (g *GenericConnector) GetSecretOutputs(secrets []string) map[string]secret.Output {
 	secretOutputs := make(map[string]secret.Output, 0)
-	for _, s := range secrets {
-		segments := strings.SplitN(s, ";", 2)
-		secretOutputs[segments[1]] = g.Backend.GetSecretOutput(segments[1])
+	for _, secretKey := range secrets {
+		segments := strings.SplitN(secretKey, ";", 2)
+		secretOutputs[secretKey] = g.Backend.GetSecretOutput(segments[1])
 	}
 	return secretOutputs
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -9,7 +9,6 @@ package backend
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/DataDog/datadog-secret-backend/backend/akeyless"
 	"github.com/DataDog/datadog-secret-backend/backend/aws"
@@ -92,9 +91,8 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 // GetSecretOutputs returns a the value for a list of given secrets of form "<secret key>"
 func (g *GenericConnector) GetSecretOutputs(secrets []string) map[string]secret.Output {
 	secretOutputs := make(map[string]secret.Output, 0)
-	for _, secretKey := range secrets {
-		segments := strings.SplitN(secretKey, ";", 2)
-		secretOutputs[secretKey] = g.Backend.GetSecretOutput(segments[1])
+	for _, secretString := range secrets {
+		secretOutputs[secretString] = g.Backend.GetSecretOutput(secretString)
 	}
 	return secretOutputs
 }

--- a/backend/backend.go
+++ b/backend/backend.go
@@ -40,7 +40,7 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 			g.Backend = backend
 		}
 	case "aws.ssm":
-		backend, err := aws.NewSSMParameterStoreBackend(backendConfig, nil)
+		backend, err := aws.NewSSMParameterStoreBackend(backendConfig)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {

--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -62,7 +62,7 @@ The following `aws_session` settings are available on all supported AWS Service 
 
 In most cases, you'll need to specify `aws_region` to correspond to the region hosting the target Parameter Store (aws.ssm) or Secrets Manager (aws.secrets) secret.
 
-When handling single strings, the backend configuration setting `force_string: true` will coerce the secret as a string value. As a result, there will be a single secretId of `_` for the backend and can be accessed in the Datadog Agent yaml as `ENC[_]`.
+When handling single strings, the backend configuration setting `force_string: true` will coerce the secret as a string value.
 
 
 ## Example Session Configurations
@@ -87,7 +87,6 @@ secret_backend_config:
 ---
 secret_backend_type: aws.secrets
 secret_backend_config:
-  secret_id: My-Secret-Backend-Secret
   aws_session:
     aws_region: us-east-1
 ```

--- a/docs/aws/README.md
+++ b/docs/aws/README.md
@@ -73,10 +73,6 @@ When handling single strings, the backend configuration setting `force_string: t
 ---
 secret_backend_type: aws.ssm
 secret_backend_config:
-  parameters: 
-    - /DatadogAgent/Production/ParameterKey1
-    - /DatadogAgent/Production/ParameterKey2
-    - /DatadogAgent/Production/ParameterKey3
   aws_session:
     aws_region: us-east-1
 ```

--- a/docs/aws/secrets.md
+++ b/docs/aws/secrets.md
@@ -52,11 +52,11 @@ secret_backend_config:
 
 ```
 
-**secret_backend_type** must be set to `aws.secrets` and **secret_id** must be set your target AWS Secrets Manager secret friendly name or ARN.
+**secret_backend_type** must be set to `aws.secrets`.
 
 Cross-account Secrets Manager secrets are supported and tested, but require appropriate permissions on the secret as well as a KMS customer managed key. More details on this configuration is available on the AWS Secrets Manager [documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html).
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation. The **secretId** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined. The **secretKey** is the actual secret that you are trying to pull the value of.
+The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation, taking the form **ENC[secretId;secretKey]**. The **secretId** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined. The **secretKey** is the actual secret that you are trying to pull the value of.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml

--- a/docs/aws/secrets.md
+++ b/docs/aws/secrets.md
@@ -49,20 +49,19 @@ secret_backend_type: aws.secrets
 secret_backend_config:
   aws_session:
     aws_region: {regionName}
-  secret_id: {secretId}
 
 ```
 
-**secret_backend_type** must be set to `aws.secrets` and **secret_id** must be set your target AWS Secrets Manager secret friendly name or ARN. The **secret_id** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined.
+**secret_backend_type** must be set to `aws.secrets` and **secret_id** must be set your target AWS Secrets Manager secret friendly name or ARN.
 
 Cross-account Secrets Manager secrets are supported and tested, but require appropriate permissions on the secret as well as a KMS customer managed key. More details on this configuration is available on the AWS Secrets Manager [documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html).
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation.
+The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation. The **secretId** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined. The **secretKey** is the actual secret that you are trying to pull the value of.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 
-api_key: ENC[{secretId}]
+api_key: ENC[{secretId};{secretKey}]
 
 ```
 
@@ -81,16 +80,15 @@ AWS Secrets Manager can hold multiple secret keys and values. A backend configur
 ---
 secret_backend_type: aws.secrets
 secret_backend_config:
-  secret_id: My-Secret-Backend-Secret
   aws_session:
     aws_region: us-east-1
 ```
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
-property1: ENC[SecretKey1]
-property2: ENC[SecretKey2]
-property3: ENC[SecretKey3]
+property1: ENC[My-Secret-Backend-Secret;SecretKey1]
+property2: ENC[My-Secret-Backend-Secret;SecretKey2]
+property3: ENC[My-Secret-Backend-Secret;SecretKey3]
 ```
 
 Multiple secret backends, of the same or different types, can be defined in your `datadog-secret-backend` yaml configuration. As a result, you can leverage multiple supported backends (file.yaml, file.json, aws.ssm, and aws.secrets) in your Datadog Agent configuration.
@@ -119,7 +117,7 @@ Each of the following examples will access the secret from the Datadog Agent con
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
-api_key: ENC[api_key] 
+api_key: ENC[/DatadogAgent/Production;api_key] 
 ```
 
 **AWS IAM User Access Key with Secrets Manager secret in same AWS account**
@@ -129,7 +127,6 @@ api_key: ENC[api_key]
 ---
 secret_backend_type: aws.secrets
 secret_backend_config:
-  secret_id: /DatadogAgent/Production
   aws_session:
     aws_region: us-east-1
 ```

--- a/docs/aws/secrets.md
+++ b/docs/aws/secrets.md
@@ -56,7 +56,7 @@ secret_backend_config:
 
 Cross-account Secrets Manager secrets are supported and tested, but require appropriate permissions on the secret as well as a KMS customer managed key. More details on this configuration is available on the AWS Secrets Manager [documentation](https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_examples_cross.html).
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation, taking the form **ENC[secretId;secretKey]**. The **secretId** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined. The **secretKey** is the actual secret that you are trying to pull the value of.
+The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation, taking the form **ENC[secretId;secretKey]**. The **secretId** value can be the secret friendly name, e.g. `/DatadogAgent/Production`, or the full ARN format, e.g `arn:aws:secretsmanager:us-east-1:123456789012:secret:/DatadogAgent/Production-FOga1K`. The full ARN format is required when accessing secrets from an a different account where the AWS credential (or sts:AssumeRole credential) is defined. The **secretKey** is the json key referring to the actual secret that you are trying to pull the value of.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml

--- a/docs/aws/ssm.md
+++ b/docs/aws/ssm.md
@@ -52,28 +52,22 @@ The backend configuration for AWS SSM Parameter Store secrets has the following 
 ---
 secret_backend_type: aws.ssm
 secret_backend_config:
-  parameters: 
-    - /DatadogAgent/Production/ParameterKey1
-    - /DatadogAgent/Production/ParameterKey2
-    - /DatadogAgent/Production/ParameterKey3
-  parameter_path: /DatadogAgent/Production
   aws_session:
     aws_region: us-east-1
 ```
 
-**secret_backend_type** must be set to `aws.ssm` and either or both of **parameter_path** and **parameters** must be provided in each backend configuration.
+**secret_backend_type** must be set to `aws.ssm`.
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation.
+The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation. Make sure to put a *semicolon* (;) before specifying your parameter path.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 
-api_key: ENC[{parameter_full_path}]
+api_key: ENC[;{parameter_full_path}]
 
 ```
 
-AWS System Manager Parameter store supports a heirachical model. Parameters can be specified individually using **parameters**, or recursively fetched using a matching
- prefix path with **parameter_path**. For example, assuming the AWS System Manager Parameter Store paths
+AWS System Manager Parameter store supports a heirachical model. For example, assuming the AWS System Manager Parameter Store paths
 
 ```sh
 /DatadogAgent/Production/ParameterKey1 = ParameterStringValue1
@@ -81,29 +75,13 @@ AWS System Manager Parameter store supports a heirachical model. Parameters can 
 /DatadogAgent/Production/ParameterKey3 = ParameterStringValue3
 ```
 
-The parameters can be fetched using **parameter_path**:
+The parameters can be fetched like so:
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 ---
 secret_backend_type: aws.ssm
 secret_backend_config:
-  parameter_path: /DatadogAgent/Production
-  aws_session:
-    aws_region: us-east-1
-```
-
-or fetched using **parameters**:
-
-```yaml
-# /etc/datadog-agent/datadog.yaml
----
-secret_backend_type: aws.ssm
-secret_backend_config:
-  parameters: 
-    - /DatadogAgent/Production/ParameterKey1
-    - /DatadogAgent/Production/ParameterKey2
-    - /DatadogAgent/Production/ParameterKey3
   aws_session:
     aws_region: us-east-1
 ```
@@ -112,14 +90,12 @@ and finally accessed in the Datadog Agent:
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
-property1: "ENC[/DatadogAgent/Production/ParameterKey1]"
-property2: "ENC[/DatadogAgent/Production/ParameterKey2]"
-property3: "ENC[/DatadogAgent/Production/ParameterKey3]"
+property1: "ENC[;/DatadogAgent/Production/ParameterKey1]"
+property2: "ENC[;/DatadogAgent/Production/ParameterKey2]"
+property3: "ENC[;/DatadogAgent/Production/ParameterKey3]"
 ```
 
 Currently, `StringList` parameter store values will be retained as a comma-separated list. `SecureString` will be properly decrypted automatically, assuming the `aws_session` credentials have appropriate rights to the KMS key used to encrypt the `SecureString` value.
-
-Multiple secret backends, of the same or different types, can be defined in your `datadog-secret-backend` yaml configuration. As a result, you can leverage multiple supported backends (file.yaml, file.json, aws.ssm, and aws.secrets) in your Datadog Agent configuration.
 
 ## Configuration Examples
 
@@ -143,7 +119,7 @@ Each of the following examples will access the secret from the Datadog Agent con
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
-api_key: "ENC[/DatadogAgent/Production/api_key]" 
+api_key: "ENC[;/DatadogAgent/Production/api_key]" 
 ```
 
 **AWS IAM User Access Key with SSM parameter_path recursive fetch**
@@ -153,7 +129,6 @@ api_key: "ENC[/DatadogAgent/Production/api_key]"
 ---
 secret_backend_type: aws.ssm
 secret_backend_config:
-parameter_path: /DatadogAgent/Production
 aws_session:
   aws_region: us-east-1
 ```

--- a/docs/aws/ssm.md
+++ b/docs/aws/ssm.md
@@ -58,12 +58,12 @@ secret_backend_config:
 
 **secret_backend_type** must be set to `aws.ssm`.
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation. Make sure to put a *semicolon* (;) before specifying your parameter path.
+The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 
-api_key: ENC[;{parameter_full_path}]
+api_key: ENC[{parameter_full_path}]
 
 ```
 
@@ -90,9 +90,9 @@ and finally accessed in the Datadog Agent:
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
-property1: "ENC[;/DatadogAgent/Production/ParameterKey1]"
-property2: "ENC[;/DatadogAgent/Production/ParameterKey2]"
-property3: "ENC[;/DatadogAgent/Production/ParameterKey3]"
+property1: "ENC[/DatadogAgent/Production/ParameterKey1]"
+property2: "ENC[/DatadogAgent/Production/ParameterKey2]"
+property3: "ENC[/DatadogAgent/Production/ParameterKey3]"
 ```
 
 Currently, `StringList` parameter store values will be retained as a comma-separated list. `SecureString` will be properly decrypted automatically, assuming the `aws_session` credentials have appropriate rights to the KMS key used to encrypt the `SecureString` value.
@@ -119,7 +119,7 @@ Each of the following examples will access the secret from the Datadog Agent con
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
-api_key: "ENC[;/DatadogAgent/Production/api_key]" 
+api_key: "ENC[/DatadogAgent/Production/api_key]" 
 ```
 
 **AWS IAM User Access Key with SSM parameter_path recursive fetch**

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	if inputPayload.Config == nil {
 		inputPayload.Config = make(map[string]interface{})
 	}
-	backend.InitBackend(inputPayload.Type, inputPayload.Config, inputPayload.Secrets)
+	backend.InitBackend(inputPayload.Type, inputPayload.Config)
 	secretOutputs := backend.GetSecretOutputs(inputPayload.Secrets)
 
 	output, err := json.Marshal(secretOutputs)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Instead of requiring secret_id in the AWS SecretsConfig, we are asking customer place the secret_id in the ENC[] value (`ENC[secret_id;secret_key]` instead of `ENC[secret_id]`). For SSM, we just reuse the parameter path from the ENC[] value to get the secret.
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This will reduce the number of config options that the customer needs to specify, improving ease of configuration.
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit testing, and actually using an SGC executable incorporating these changes to retrieve secrets.