### PR TITLE
[AGENTCFG-307] Removing secret_path from the AWS Hashicorp Config

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -54,7 +54,7 @@ func (g *GenericConnector) InitBackend(backendType string, backendConfig map[str
 			g.Backend = backend
 		}
 	case "hashicorp.vault":
-		backend, err := hashicorp.NewVaultBackend(backendConfig, nil)
+		backend, err := hashicorp.NewVaultBackend(backendConfig)
 		if err != nil {
 			g.Backend = NewErrorBackend(err)
 		} else {

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -24,7 +24,6 @@ type VaultBackendConfig struct {
 	VaultToken   string                    `mapstructure:"vault_token"`
 	BackendType  string                    `mapstructure:"backend_type"`
 	VaultAddress string                    `mapstructure:"vault_address"`
-	SecretPath   string                    `mapstructure:"secret_path"`
 	VaultTLS     *VaultTLSConfig           `mapstructure:"vault_tls_config"`
 }
 
@@ -140,7 +139,6 @@ func (b *VaultBackend) GetSecretOutput(secretKey string) secret.Output {
 
 	log.Error().
 		Str("backend_type", b.Config.BackendType).
-		Str("secret_path", b.Config.SecretPath).
 		Str("secret_key", segments[1]).
 		Msg("failed to retrieve secrets")
 	return secret.Output{Value: nil, Error: &es}

--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -40,7 +40,6 @@ func TestVaultBackend(t *testing.T) {
 	secretsBackend, err := NewVaultBackend(backendConfig)
 	assert.NoError(t, err)
 
-	// Fix: Use the correct format "secret_path;secret_key"
 	secretOutput := secretsBackend.GetSecretOutput("secret/foo;key1")
 	assert.Equal(t, "value1", *secretOutput.Value)
 	assert.Nil(t, secretOutput.Error)
@@ -75,7 +74,6 @@ func TestVaultBackend_KeyNotFound(t *testing.T) {
 	secretsBackend, err := NewVaultBackend(backendConfig)
 	assert.NoError(t, err)
 
-	// Fix: Use the correct format "secret_path;secret_key"
 	secretOutput := secretsBackend.GetSecretOutput("secret/foo;key_noexist")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)

--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -30,10 +30,9 @@ func TestVaultBackend(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a new Vault backend.
-	inputSecrets := []string{"key1", "key2"}
+	inputSecrets := []string{"secret/foo;key1", "secret/foo;key2"}
 	backendConfig := map[string]interface{}{
 		"vault_address": client.Address(),
-		"secret_path":   "secret/foo",
 		"backend_type":  "hashicorp.vault",
 		// Note: we're not testing the whole "session" part of the backend here as we're using the root token.
 		"vault_token": token,
@@ -42,11 +41,11 @@ func TestVaultBackend(t *testing.T) {
 	secretsBackend, err := NewVaultBackend(backendConfig, inputSecrets)
 	assert.NoError(t, err)
 
-	secretOutput := secretsBackend.GetSecretOutput("key1")
+	secretOutput := secretsBackend.GetSecretOutput("secret/foo;key1")
 	assert.Equal(t, "value1", *secretOutput.Value)
 	assert.Nil(t, secretOutput.Error)
 
-	secretOutput = secretsBackend.GetSecretOutput("key_noexist")
+	secretOutput = secretsBackend.GetSecretOutput("secret/foo;key_noexist")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }
@@ -62,10 +61,9 @@ func TestVaultBackend_KeyNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Create a new Vault backend.
-	inputSecrets := []string{"key_noexist"}
+	inputSecrets := []string{"secret/foo;key_noexist"}
 	backendConfig := map[string]interface{}{
 		"vault_address": client.Address(),
-		"secret_path":   "secret/foo",
 		"backend_type":  "hashicorp.vault",
 		// Note: we're not testing the whole "session" part of the backend here as we're using the root token.
 		"vault_token": token,
@@ -75,15 +73,15 @@ func TestVaultBackend_KeyNotFound(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that the keys are not found.
-	secretOutput := secretsBackend.GetSecretOutput("key1")
+	secretOutput := secretsBackend.GetSecretOutput("secret/foo;key1")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 
-	secretOutput = secretsBackend.GetSecretOutput("key2")
+	secretOutput = secretsBackend.GetSecretOutput("secret/foo;key2")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 
-	secretOutput = secretsBackend.GetSecretOutput("key_noexist")
+	secretOutput = secretsBackend.GetSecretOutput("secret/foo;key_noexist")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }

--- a/docs/hashicorp/README.md
+++ b/docs/hashicorp/README.md
@@ -83,7 +83,6 @@ The following `vault_session` settings are available:
 secret_backend_type: hashicorp.vault
 secret_backend_config:
   vault_address: vault_address: http://myvaultaddress.net
-  secret_path: /Datadog/Production
   vault_session:
     vault_auth_type: aws
     vault_aws_role: Name-of-IAM-role-attached-to-machine

--- a/docs/hashicorp/vault.md
+++ b/docs/hashicorp/vault.md
@@ -9,8 +9,6 @@
 | Setting | Description |
 | --- | --- |
 | backend_type | Backend type |
-| secret_path| Vault secret prefix, recursive |
-| secrets | List of individual Vault secrets |
 | vault_address | DNS/IP of the Hashicorp Vault system |
 | vault_tls_config | TLS Configuration to access the Vault system |
 | vault_session | Authentication configuration to access the Vault system |
@@ -57,7 +55,6 @@ secret_backend_config:
   vault_address: vault_address: http://myvaultaddress.net
   vault_tls_config:
       # ... TLS settings if applicable
-  secret_path: /Datadog/Production
   vault_session:
     vault_role_id: 123456-************
     vault_secret_id: abcdef-********

--- a/docs/hashicorp/vault.md
+++ b/docs/hashicorp/vault.md
@@ -92,7 +92,7 @@ api_key: "ENC[/Datadog/Production;apikey]"
 ---
 secret_backend_type: hashicorp.vault
 secret_backend_config:
-  vault_address: vault_address: http://myvaultaddress.net
+  vault_address: http://myvaultaddress.net
   vault_session:
     vault_auth_type: aws
     vault_aws_role: Name-of-IAM-role-attached-to-machine

--- a/docs/hashicorp/vault.md
+++ b/docs/hashicorp/vault.md
@@ -41,17 +41,16 @@ secret_backend_config:
   vault_session:
     vault_auth_type: aws
     # ... additional session settings
-  secret_path: /Path/To/Secrets
 ```
 
 **backend_type** must be set to `hashicorp.vault`.
 
-The backend secret is referenced in your Datadog Agent configuration file using the **ENC** notation.
+The path to the secret and the backend secret itself is referenced in your Datadog Agent configuration file using the **ENC** notation. The two need to be separated by a semicolon.
 
 ```yaml
 # /etc/datadog-agent/datadog.yaml
 
-api_key: "ENC[{secret}]"
+api_key: "ENC[{secret_path};{secret}]"
 
 secret_backend_type: hashicorp.vault
 secret_backend_config:
@@ -86,7 +85,7 @@ Each of the following examples will access the secret from the Datadog Agent con
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
-api_key: "ENC[apikey]" 
+api_key: "ENC[/Datadog/Production;apikey]" 
 ```
 
 ### Hashicorp Vault Authentication with AWS Instance Profile
@@ -97,7 +96,6 @@ api_key: "ENC[apikey]"
 secret_backend_type: hashicorp.vault
 secret_backend_config:
   vault_address: vault_address: http://myvaultaddress.net
-  secret_path: /Datadog/Production
   vault_session:
     vault_auth_type: aws
     vault_aws_role: Name-of-IAM-role-attached-to-machine


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Instead of requiring secret_path in the AWS Hashicorp, we are asking customer place the secret_path in the ENC[] value (`ENC[secret_path;secret_id]` instead of `ENC[secret_id]`). 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This will reduce the number of config options that the customer needs to specify, improving ease of configuration.
### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit testing, and actually using an SGC executable incorporating these changes to retrieve secrets.