### PR TITLE
Allow Azure secrets to be flat strings, or json

### DIFF
--- a/backend/azure/keyvault_test.go
+++ b/backend/azure/keyvault_test.go
@@ -64,8 +64,6 @@ func TestKeyvaultBackend(t *testing.T) {
 	secretOutput = keyvaultSecretsBackend.GetSecretOutput("key3")
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
-
-	assert.Equal(t, 1, 2)
 }
 
 func TestKeyVaultBackend_issue39434(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Support flat top-level secrets in Azure, or json structured secrets similar to how AWS works. The semi-colon is used to index into structured secrets.

### Motivation

More flexible functionality.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Unit tests cover this change.
