### PR TITLE
[AGENTCFG-354] adding v2 server support for hashicorp

### DIFF
--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -189,7 +189,6 @@ func (b *VaultBackend) GetSecretOutput(secretKey string) secret.Output {
 func isKVv2Mount(client *api.Client, secretPath string) (bool, string) {
 	mounts, err := client.Sys().ListMounts()
 	if err != nil {
-		log.Warn().Err(err).Msg("Failed to list Vault mounts")
 		return false, ""
 	}
 

--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -114,21 +114,29 @@ func TestVaultBackend_KVV2Support(t *testing.T) {
 	ln, client, token := createTestVault(t)
 	defer ln.Close()
 
+	err := client.Sys().Mount("kv2/", &api.MountInput{
+		Type: "kv",
+		Options: map[string]string{
+			"version": "2",
+		},
+	})
+	assert.NoError(t, err)
+
 	// Simulate KV v2 structure: {"data": {"key1": "value1", "key2": "value2"}, "metadata": {"something": "else"}}
-	_, err := client.Logical().Write("secret/foo", map[string]interface{}{
+	_, err = client.Logical().Write("kv2/data/foo", map[string]interface{}{
 		"data": map[string]interface{}{
 			"key1": "value1",
 			"key2": "value2",
 		},
 		"metadata": map[string]interface{}{
-			"version": 1,
+			"custom_metadata": "custom_value",
 		},
 	})
 	assert.NoError(t, err)
 
 	backendConfig := map[string]interface{}{
 		"vault_address": client.Address(),
-		"secret_path":   "secret/foo", // Simulated KV v2 response
+		"secret_path":   "kv2/foo", // Simulated KV v2 response
 		"secrets":       []string{"key1", "key2"},
 		"backend_type":  "hashicorp.vault",
 		"vault_token":   token,

--- a/docs/hashicorp/README.md
+++ b/docs/hashicorp/README.md
@@ -6,10 +6,10 @@ The `datadog-secret-backend` utility currently supports the following Hashicorp 
 
 | Backend Type | Hashicorp Service |
 | --- | --- |
-| [hashicorp.vault](vault.md) | [Hashicorp Vault](https://learn.hashicorp.com/tutorials/vault/static-secrets) |
+| [hashicorp.vault](vault.md) | [Hashicorp Vault (Secrets Engine Version 1)](https://learn.hashicorp.com/tutorials/vault/static-secrets) |
+| [hashicorp.vault](vault.md) | [Hashicorp Vault (Secrets Engine Version 2)](https://learn.hashicorp.com/tutorials/vault/static-secrets) |
 
-
-## Hashicorp ault Session
+## Hashicorp Vault Session
 
 Hashicorp Vault supports a variety of authentication methods. The ones currently supported by this module are as follows:
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

We would like to support both versions 1 and 2 of the Hashicorp Secrets Engine. However, the json output of `kv get` differs depending on the version, thus requiring some extra code. 

In v1,
```
{
  "request_id": <some-id>,
  "lease_id": "",
  "lease_duration": 2764800,
  "renewable": false,
  "data": {
    "apikey": "your_real_datadog_api_key"
  },
  "warnings": null,
  "mount_type": "kv"
}
```

In v2,
```
{
  "request_id": <some-id>,
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "data": {
      "apikey": "your_real_datadog_api_key"
    },
    "metadata": {
      "created_time": "2025-07-29T18:24:40.860641868Z",
      "custom_metadata": null,
      "deletion_time": "",
      "destroyed": false,
      "version": 1
    }
  },
  "warnings": null,
  "mount_type": "kv"
}
```

We use the following api to check the version: [sys/mounts](https://developer.hashicorp.com/vault/api-docs/system/mounts). Specifically, we look at the list of mounts for the mount that the customer set for their secret's mount path (which should be a super-path of their "secret path"), and then it should be nested like so:
```
"options": {
  "version": "<version-number>"
},
```
### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

I built an executable with these changes, and requested secrets from a v2 engine successfully.
