### PR TITLE
[AGENTCFG-355] Adding v2 server support for hashicorp for v1 of SGC

### DIFF
--- a/docs/hashicorp/README.md
+++ b/docs/hashicorp/README.md
@@ -7,7 +7,7 @@ The `datadog-secret-backend` utility currently supports the following Hashicorp 
 | Backend Type | Hashicorp Service |
 | --- | --- |
 | [hashicorp.vault](vault.md) | [Hashicorp Vault (Secrets Engine Version 1)](https://learn.hashicorp.com/tutorials/vault/static-secrets) |
-
+| [hashicorp.vault](vault.md) | [Hashicorp Vault (Secrets Engine Version 2)](https://learn.hashicorp.com/tutorials/vault/static-secrets) |
 
 ## Hashicorp auth Session
 

--- a/docs/hashicorp/README.md
+++ b/docs/hashicorp/README.md
@@ -22,11 +22,21 @@ Using environment variables are more complex as they must be configured within t
 ## General Instructions to set up Hashicorp Vault
 1. Run your Hashicorp Vault. For more information on how to do this, please look at the [official Hashicorp Vault documentation](https://www.hashicorp.com/en/products/vault). 
 2. When running the vault, you should have received the variables `VAULT_ADDR` and `VAULT_TOKEN`. Export them as environment variables.
-3. To store your secrets in a certain path, run `vault secrets enable -path=<your path> -version=1 kv` *NOTE*: As of now, only version 1 of the Hashicrop Secrets Engine is supported.
-4. To add your key, run `vault kv put <your path> apikey=your_real_datadog_api_key`. You can conversely run `vault kv get ...` to get said key.
-5. Now you need to write a policy to give permission to pull secrets from your vault. Create a *.hcl file, and include the following permission:
+3. To store your secrets in a certain path, run `vault secrets enable -path=<your mount path> -version=1 kv`  or `vault secrets enable -path=<your mount path> -version=2 kv` (you can choose which version of the secrets engine to use).
+4. To add your key, run `vault kv put <your mount path>/<additional subpath> apikey=your_real_datadog_api_key`. You can conversely run `vault kv get ...` to get said key.
+5. Now you need to write a policy to give permission to pull secrets from your vault. Create a *.hcl file. If you are using version 1 of the secrets engine, the file should look like this:
 ```
-path "<your path>" {
+path "<your mount path>/<additional subpath>" {
+  capabilities = ["read"]
+}
+```
+If you are using version 2 of the secrets engine, the file should look like this:
+```
+path "<your mount path>/data/<additional subpath>" {
+  capabilities = ["read"]
+}
+
+path "sys/mounts" {
   capabilities = ["read"]
 }
 ```


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

_**NOTE: since this will be going into v7.70 or 7.71 of the agent, we should avoid updating the public-facing docs with the doc updates in this pr until the relevant agent version comes out.**_

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
We would like to support both versions 1 and 2 of the Hashicorp Secrets Engine. However, the json output of `kv get` differs depending on the version, thus requiring some extra code. 

In v1,
```
{
  "request_id": <some-id>,
  "lease_id": "",
  "lease_duration": 2764800,
  "renewable": false,
  "data": {
    "apikey": "your_real_datadog_api_key"
  },
  "warnings": null,
  "mount_type": "kv"
}
```

In v2,
```
{
  "request_id": <some-id>,
  "lease_id": "",
  "lease_duration": 0,
  "renewable": false,
  "data": {
    "data": {
      "apikey": "your_real_datadog_api_key"
    },
    "metadata": {
      "created_time": "2025-07-29T18:24:40.860641868Z",
      "custom_metadata": null,
      "deletion_time": "",
      "destroyed": false,
      "version": 1
    }
  },
  "warnings": null,
  "mount_type": "kv"
}
```

We use the following api to check the version: [sys/mounts](https://developer.hashicorp.com/vault/api-docs/system/mounts). Specifically, we look at the list of mounts for the mount that the customer set for their secret's mount path (which should be a super-path of their "secret path"), and then it should be nested like so:
```
"options": {
  "version": "<version-number>"
},
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
I QA-ed by setting up a vault, and then storing a secret in v1 and v2 of the secrets engine. I was able to request for secrets from both successfully.
