### PR TITLE
Azure requires clientid field to be on secret_backend_config

### DIFF
--- a/backend/azure/keyvault_test.go
+++ b/backend/azure/keyvault_test.go
@@ -42,13 +42,14 @@ func TestKeyvaultBackend(t *testing.T) {
 			"key2": "{\"foo\":\"bar\"}",
 		},
 	}
-	getKeyvaultClient = func(_ string) (keyvaultClient, error) {
+	getKeyvaultClient = func(_, _ string) (keyvaultClient, error) {
 		return mockClient, nil
 	}
 
 	keyvaultBackendParams := map[string]interface{}{
 		"backend_type": "azure.keyvault",
 		"keyvaulturl":  "https://my-vault.vault.azure.com/",
+		"clientid":     "123abc45-123a-abcd-123a-123abc456def",
 	}
 	keyvaultSecretsBackend, err := NewKeyVaultBackend(keyvaultBackendParams)
 	assert.NoError(t, err)
@@ -72,12 +73,13 @@ func TestKeyVaultBackend_issue39434(t *testing.T) {
 			"key1": "{\\\"foo\\\":\\\"bar\\\"}",
 		},
 	}
-	getKeyvaultClient = func(_ string) (keyvaultClient, error) {
+	getKeyvaultClient = func(_, _ string) (keyvaultClient, error) {
 		return mockClient, nil
 	}
 
 	keyvaultBackendParams := map[string]interface{}{
 		"backend_type": "azure.keyvault",
+		"clientid":     "123abc45-123a-abcd-123a-123abc456def",
 	}
 	keyvaultSecretsBackend, err := NewKeyVaultBackend(keyvaultBackendParams)
 	assert.NoError(t, err)


### PR DESCRIPTION
### What does this PR do?

Instead of depending on the env var `AZURE_CLIENT_ID`, require the input config to set the field for the managed identity's clientID.

### Motivation

Prefer not to require env vars to be assigned.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
