### PR TITLE
Allow for the passing in of the VAULT_ADDR env var

### DIFF
--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -179,7 +179,16 @@ func NewVaultBackend(bc map[string]interface{}) (*VaultBackend, error) {
 		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
 	}
 
-	clientConfig := &api.Config{Address: backendConfig.VaultAddress}
+	vaultAddress := backendConfig.VaultAddress
+	if vaultAddress == "" {
+		if envPath := os.Getenv("VAULT_ADDR"); envPath != "" {
+			vaultAddress = envPath
+		} else {
+			return nil, fmt.Errorf("failed to provide a vault address: %s", err)
+		}
+	}
+
+	clientConfig := &api.Config{Address: vaultAddress}
 
 	if backendConfig.VaultTLS != nil {
 		tlsConfig := &api.TLSConfig{

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -155,9 +155,6 @@ func newVaultConfigFromBackendConfig(sessionConfig VaultSessionBackendConfig) (a
 		if authPath == "" {
 			authPath = sessionConfig.VaultKubernetesMountPath
 		}
-		if authPath == "" {
-			return nil, fmt.Errorf("authPath not specified")
-		}
 		authPath = strings.TrimPrefix(authPath, "auth/")
 		authPath = strings.TrimSuffix(authPath, "/login")
 

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -179,10 +179,10 @@ func NewVaultBackend(bc map[string]interface{}) (*VaultBackend, error) {
 		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
 	}
 
-	vaultAddress := backendConfig.VaultAddress
+	vaultAddress := os.Getenv("VAULT_ADDR")
 	if vaultAddress == "" {
-		if envPath := os.Getenv("VAULT_ADDR"); envPath != "" {
-			vaultAddress = envPath
+		if configPath := backendConfig.VaultAddress; configPath != "" {
+			vaultAddress = configPath
 		} else {
 			return nil, fmt.Errorf("failed to provide a vault address: %s", err)
 		}

--- a/backend/hashicorp/vault.go
+++ b/backend/hashicorp/vault.go
@@ -70,10 +70,10 @@ func getKubernetesJWTToken(sessionConfig VaultSessionBackendConfig) (string, err
 		return sessionConfig.VaultKubernetesJWT, nil
 	}
 
-	tokenPath := sessionConfig.VaultKubernetesJWTPath
+	tokenPath := os.Getenv("DD_SECRETS_SA_TOKEN_PATH")
 	if tokenPath == "" {
-		if envPath := os.Getenv("DD_SECRETS_SA_TOKEN_PATH"); envPath != "" {
-			tokenPath = envPath
+		if configPath := sessionConfig.VaultKubernetesJWTPath; configPath != "" {
+			tokenPath = configPath
 		} else {
 			tokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 		}
@@ -134,9 +134,9 @@ func newVaultConfigFromBackendConfig(sessionConfig VaultSessionBackendConfig) (a
 	}
 
 	if sessionConfig.VaultAuthType == "kubernetes" {
-		role := sessionConfig.VaultKubernetesRole
+		role := os.Getenv("DD_SECRETS_VAULT_ROLE")
 		if role == "" {
-			role = os.Getenv("DD_SECRETS_VAULT_ROLE")
+			role = sessionConfig.VaultKubernetesRole
 		}
 		if role == "" {
 			return nil, fmt.Errorf("kubernetes role not specified")
@@ -151,15 +151,18 @@ func newVaultConfigFromBackendConfig(sessionConfig VaultSessionBackendConfig) (a
 			kubernetes.WithServiceAccountToken(jwtToken),
 		}
 
-		if sessionConfig.VaultKubernetesMountPath == "" {
-			if authPath := os.Getenv("DD_SECRETS_VAULT_AUTH_PATH"); authPath != "" {
-				authPath = strings.TrimPrefix(authPath, "auth/")
-				authPath = strings.TrimSuffix(authPath, "/login")
-				sessionConfig.VaultKubernetesMountPath = authPath
-			}
+		authPath := os.Getenv("DD_SECRETS_VAULT_AUTH_PATH")
+		if authPath == "" {
+			authPath = sessionConfig.VaultKubernetesMountPath
 		}
-		if sessionConfig.VaultKubernetesMountPath != "" {
-			opts = append(opts, kubernetes.WithMountPath(sessionConfig.VaultKubernetesMountPath))
+		if authPath == "" {
+			return nil, fmt.Errorf("authPath not specified")
+		}
+		authPath = strings.TrimPrefix(authPath, "auth/")
+		authPath = strings.TrimSuffix(authPath, "/login")
+
+		if authPath != "" {
+			opts = append(opts, kubernetes.WithMountPath(authPath))
 		}
 
 		auth, err = kubernetes.NewKubernetesAuth(role, opts...)

--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -405,6 +405,17 @@ func TestNewVaultConfigFromBackendConfig_KubernetesAuth(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Kubernetes auth with custom mount path (remove auth/ and /login)",
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:            "kubernetes",
+				VaultKubernetesRole:      "test-role",
+				VaultKubernetesJWT:       "test-jwt-token",
+				VaultKubernetesMountPath: "auth/custom/auth/path/login",
+			},
+			expectAuth:  true,
+			expectError: false,
+		},
+		{
 			name: "Kubernetes auth with mount path from env var",
 			sessionConfig: VaultSessionBackendConfig{
 				VaultAuthType:       "kubernetes",

--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -412,7 +412,7 @@ func TestNewVaultConfigFromBackendConfig_KubernetesAuth(t *testing.T) {
 				VaultKubernetesJWT:  "test-jwt-token",
 			},
 			envVars: map[string]string{
-				"VAULT_AUTH_PATH": "env/auth/path",
+				"DD_SECRETS_VAULT_AUTH_PATH": "env/auth/path",
 			},
 			expectAuth:  true,
 			expectError: false,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

We currently need to provide `vault_address` as a config option within `secret_backend_config`. This is unnecessary internally, as we can just read the env var `VAULT_ADDR`. By allowing for passing in this env var, we don't need this datacenter-specific config option, allowing us to set usage of SGC on the environment-specific config file (ex: staging.yaml) as opposed to need to change the config for every datacenter.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

How I QA'd:

1. Run `GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -gcflags=all="-l" -o secret-generic-connector main.go` to get a linux version of the binary
2. Find a x86 `datadog-agent-*` pod in the datadog-agent namespace
3. copy over the binary to the pod: `kubectl cp <binary location> datadog-agent/<pod name>:/ -n datadog-agent`
4. exec into the pod and give the binary execute permissions
5. Pass the protocol automatically generated by the agent into the binary, and the secret will be returned:
```
echo '{
  "version": "1.1",
  "secrets": ["vault://applications/datadog-agent/shared/agent-api-key-ddstaging.datadoghq.com#/data/value"],
  "type": "hashicorp.vault",
  "config": {
    "vault_session": {
      "vault_auth_type": "kubernetes"
    }
  }
}' | ./secret-generic-connector
{"vault://applications/datadog-agent/shared/agent-api-key-ddstaging.datadoghq.com#/data/value":{"value":"<redacted>","error":null}}
```
Note that `vault_address` didn't need to be provided in this command.
