### PR TITLE
[AGENT-14940] Allow AWS Secrets Manager secret values to be non-strings (which will be stringified during retrieval)

### DIFF
--- a/backend/aws/secrets.go
+++ b/backend/aws/secrets.go
@@ -109,13 +109,13 @@ func (b *SecretsManagerBackend) GetSecretOutput(secretString string) secret.Outp
 				case string:
 					secretValue = v
 				case map[string]interface{}, []interface{}:
+					// Marshal nested objects/arrays to JSON strings
 					if b, err := json.Marshal(v); err == nil {
 						secretValue = string(b)
 					} else {
 						secretValue = fmt.Sprintf("%v", v)
 					}
 				default:
-					// Convert numbers, booleans, etc. to string
 					secretValue = fmt.Sprintf("%v", v)
 				}
 			} else {

--- a/backend/aws/secrets_test.go
+++ b/backend/aws/secrets_test.go
@@ -174,3 +174,49 @@ func TestSecretsManagerBackend_SecretNotFound(t *testing.T) {
 	assert.NotNil(t, secretOutput.Error)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }
+
+func TestSecretsManagerBackend_NonStringValues(t *testing.T) {
+	mockClient := &secretsManagerMockClient{
+		secrets: map[string]string{
+			"key1": `{
+				"username": "datadog",
+				"port": 3306,
+				"enabled": true,
+				"threshold": 0.75,
+				"nested": { "field": "value" }
+			}`,
+		},
+	}
+	getSecretsManagerClient = func(_ aws.Config) secretsManagerClient {
+		return mockClient
+	}
+
+	secretsManagerBackendParams := map[string]interface{}{
+		"backend_type": "aws.secrets",
+		"force_string": false,
+	}
+	secretsManagerSecretsBackend, err := NewSecretsManagerBackend(secretsManagerBackendParams)
+	assert.NoError(t, err)
+	assert.NotNil(t, secretsManagerSecretsBackend)
+
+	secretOutput := secretsManagerSecretsBackend.GetSecretOutput("key1;port")
+	assert.NotNil(t, secretOutput.Value)
+	assert.Equal(t, "3306", *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
+
+	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key1;enabled")
+	assert.NotNil(t, secretOutput.Value)
+	assert.Equal(t, "true", *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
+
+	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key1;threshold")
+	assert.NotNil(t, secretOutput.Value)
+	assert.Equal(t, "0.75", *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
+
+	// Nested object should be JSON-encoded string
+	secretOutput = secretsManagerSecretsBackend.GetSecretOutput("key1;nested")
+	assert.NotNil(t, secretOutput.Value)
+	assert.JSONEq(t, `{"field":"value"}`, *secretOutput.Value)
+	assert.Nil(t, secretOutput.Error)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Refer to the card: https://datadoghq.atlassian.net/browse/AGENT-14940. Essentially, AWS Secret Manager documentation allows for integers to be set as secret values (for example, if the secret object is `{"DDApiKey":"fake-api-value",
"port": 60}`, even retrieving `"DDApiKey"` errors due to the presence of the `"port"` key), but we were expecting the value to be a string, causing an error. We want to allow customers to set their secret values to be non-string, but then stringify them during secrets retrieval. This is okay, because we don't allow or need to allow supporting the actual retrieval of non-secrets via ENC--we only need to let non-string secrets not get in the way of pulling string secrets.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
I added a unit test, and QA-d manually on an Agent retrieving a secret object containing a string and non-string secret (the agent was able to pull the string secret via ENC, and the non-string secret didn't cause any errors).