### PR TITLE
docker secrets support

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-secret-backend/backend/akeyless"
 	"github.com/DataDog/datadog-secret-backend/backend/aws"
 	"github.com/DataDog/datadog-secret-backend/backend/azure"
+	"github.com/DataDog/datadog-secret-backend/backend/docker"
 	"github.com/DataDog/datadog-secret-backend/backend/file"
 	"github.com/DataDog/datadog-secret-backend/backend/gcp"
 	"github.com/DataDog/datadog-secret-backend/backend/hashicorp"
@@ -47,6 +48,8 @@ func Get(backendType string, backendConfig map[string]interface{}) Backend {
 		backend, err = file.NewJSONBackend(backendConfig)
 	case "akeyless":
 		backend, err = akeyless.NewAkeylessBackend(backendConfig)
+	case "docker.secrets":
+		backend, err = docker.NewSecretsBackend(backendConfig)
 	default:
 		err = fmt.Errorf("unsupported backend type: %s", backendType)
 	}

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -89,7 +89,7 @@ func (b *SecretsBackend) GetSecretOutput(_ context.Context, secretString string)
 
 	value := strings.TrimSpace(string(data))
 	if value == "" {
-		es := fmt.Sprintf("secret '%s' is empty", secretString)
+		es := secret.ErrKeyNotFound.Error()
 		return secret.Output{Value: nil, Error: &es}
 	}
 

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -56,10 +56,7 @@ func NewSecretsBackend(bc map[string]interface{}) (*SecretsBackend, error) {
 		return nil, fmt.Errorf("secrets path '%s' is not a directory", backendConfig.SecretsPath)
 	}
 
-	backend := &SecretsBackend{
-		Config: backendConfig,
-	}
-	return backend, nil
+	return &SecretsBackend{Config: backendConfig}, nil
 }
 
 // GetSecretOutput retrieves a secret from Docker Secrets

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -63,7 +63,7 @@ func NewSecretsBackend(bc map[string]interface{}) (*SecretsBackend, error) {
 }
 
 // GetSecretOutput retrieves a secret from Docker Secrets
-func (b *SecretsBackend) GetSecretOutput(ctx context.Context, secretString string) secret.Output {
+func (b *SecretsBackend) GetSecretOutput(_ context.Context, secretString string) secret.Output {
 	var path string
 
 	if filepath.IsAbs(secretString) {

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -39,7 +39,7 @@ func NewSecretsBackend(bc map[string]interface{}) (*SecretsBackend, error) {
 	}
 
 	// https://docs.docker.com/engine/swarm/secrets#how-docker-manages-secrets
-	// https: //docs.docker.com/compose/how-tos/use-secrets/#use-secrets
+	// https://docs.docker.com/compose/how-tos/use-secrets/#use-secrets
 	if backendConfig.SecretsPath == "" {
 		if runtime.GOOS == "windows" {
 			backendConfig.SecretsPath = `C:\ProgramData\Docker\secrets`

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -66,8 +66,8 @@ func (b *SecretsBackend) GetSecretOutput(_ context.Context, secretString string)
 	if filepath.IsAbs(secretString) {
 		// target support https://docs.docker.com/engine/swarm/secrets/#intermediate-example-use-secrets-with-a-nginx-service:~:text=location%20using%20the-,target,-option.%20The%20example
 		path = secretString
-	} else if strings.Contains(secretString, "..") || strings.ContainsRune(secretString, filepath.Separator) {
-		es := "invalid secret name: must not contain '..' or separator"
+	} else if strings.Contains(secretString, "..") || strings.ContainsAny(secretString, `/\`) {
+		es := "invalid secret name: must not contain '..' or path separators"
 		return secret.Output{Value: nil, Error: &es}
 	} else {
 		path = filepath.Join(b.Config.SecretsPath, secretString)

--- a/backend/docker/secrets.go
+++ b/backend/docker/secrets.go
@@ -1,0 +1,100 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
+// Package docker allows to fetch secrets from Docker Secrets (Swarm and Compose)
+package docker
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/mitchellh/mapstructure"
+
+	"github.com/DataDog/datadog-secret-backend/secret"
+)
+
+// SecretsBackendConfig is the configuration for a Docker Secrets backend
+type SecretsBackendConfig struct {
+	SecretsPath string `mapstructure:"secrets_path"` // optional
+}
+
+// SecretsBackend represents backend for Docker Secrets
+type SecretsBackend struct {
+	Config SecretsBackendConfig
+}
+
+// NewSecretsBackend returns a new Docker Secrets backend
+func NewSecretsBackend(bc map[string]interface{}) (*SecretsBackend, error) {
+	backendConfig := SecretsBackendConfig{}
+	err := mapstructure.Decode(bc, &backendConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
+	}
+
+	// https://docs.docker.com/engine/swarm/secrets#how-docker-manages-secrets
+	// https: //docs.docker.com/compose/how-tos/use-secrets/#use-secrets
+	if backendConfig.SecretsPath == "" {
+		if runtime.GOOS == "windows" {
+			backendConfig.SecretsPath = `C:\ProgramData\Docker\secrets`
+		} else {
+			backendConfig.SecretsPath = "/run/secrets"
+		}
+	}
+
+	info, err := os.Stat(backendConfig.SecretsPath)
+	if err != nil {
+		return nil, fmt.Errorf("secrets path '%s' is not accessible: %w", backendConfig.SecretsPath, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("secrets path '%s' is not a directory", backendConfig.SecretsPath)
+	}
+
+	backend := &SecretsBackend{
+		Config: backendConfig,
+	}
+	return backend, nil
+}
+
+// GetSecretOutput retrieves a secret from Docker Secrets
+func (b *SecretsBackend) GetSecretOutput(ctx context.Context, secretString string) secret.Output {
+	var path string
+
+	if filepath.IsAbs(secretString) {
+		// target support https://docs.docker.com/engine/swarm/secrets/#intermediate-example-use-secrets-with-a-nginx-service:~:text=location%20using%20the-,target,-option.%20The%20example
+		path = secretString
+	} else if strings.Contains(secretString, "..") || strings.ContainsRune(secretString, filepath.Separator) {
+		es := "invalid secret name: must not contain '..' or separator"
+		return secret.Output{Value: nil, Error: &es}
+	} else {
+		path = filepath.Join(b.Config.SecretsPath, secretString)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			es := secret.ErrKeyNotFound.Error()
+			return secret.Output{Value: nil, Error: &es}
+		}
+		if os.IsPermission(err) {
+			es := fmt.Sprintf("permission denied reading secret '%s'", secretString)
+			return secret.Output{Value: nil, Error: &es}
+		}
+		es := fmt.Sprintf("failed to read secret '%s': %s", secretString, err.Error())
+		return secret.Output{Value: nil, Error: &es}
+	}
+
+	value := strings.TrimSpace(string(data))
+	if value == "" {
+		es := fmt.Sprintf("secret '%s' is empty", secretString)
+		return secret.Output{Value: nil, Error: &es}
+	}
+
+	return secret.Output{Value: &value, Error: nil}
+}

--- a/backend/docker/secrets_test.go
+++ b/backend/docker/secrets_test.go
@@ -18,9 +18,12 @@ import (
 func TestGetSecretOutput(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	os.WriteFile(filepath.Join(tmpDir, "api_key"), []byte("api-key"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "app_key"), []byte("app-key"), 0644)
-	os.WriteFile(filepath.Join(tmpDir, "empty"), []byte(""), 0644)
+	err := os.WriteFile(filepath.Join(tmpDir, "api_key"), []byte("api-key"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "app_key"), []byte("app-key"), 0644)
+	assert.NoError(t, err)
+	err = os.WriteFile(filepath.Join(tmpDir, "empty"), []byte(""), 0644)
+	assert.NoError(t, err)
 
 	backend := &SecretsBackend{
 		Config: SecretsBackendConfig{

--- a/backend/docker/secrets_test.go
+++ b/backend/docker/secrets_test.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the BSD 3-Clause License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2024-present Datadog, Inc.
+// Copyright (c) 2021, RapDev.IO
+
+package docker
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSecretOutput(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.WriteFile(filepath.Join(tmpDir, "api_key"), []byte("api-key"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "app_key"), []byte("app-key"), 0644)
+	os.WriteFile(filepath.Join(tmpDir, "empty"), []byte(""), 0644)
+
+	backend := &SecretsBackend{
+		Config: SecretsBackendConfig{
+			SecretsPath: tmpDir,
+		},
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name   string
+		secret string
+		value  string
+		fail   bool
+	}{
+		{
+			name:   "valid secret",
+			secret: "api_key",
+			value:  "api-key",
+			fail:   false,
+		},
+		{
+			name:   "other secret",
+			secret: "app_key",
+			value:  "app-key",
+			fail:   false,
+		},
+		{
+			name:   "secret not found",
+			secret: "nonexistent",
+			fail:   true,
+		},
+		{
+			name:   "empty secret name",
+			secret: "",
+			fail:   true,
+		},
+		{
+			name:   "no relative path",
+			secret: "../etc/passwd",
+			fail:   true,
+		},
+		{
+			name:   "absolute path works",
+			secret: filepath.Join(tmpDir, "api_key"),
+			value:  "api-key",
+			fail:   false,
+		},
+		{
+			name:   "empty secret fails",
+			secret: "empty",
+			fail:   true,
+		},
+		{
+			name:   "slash in relative name blocked",
+			secret: "subdir/secret",
+			fail:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := backend.GetSecretOutput(ctx, tt.secret)
+
+			if tt.fail {
+				assert.Nil(t, output.Value)
+				assert.NotNil(t, output.Error)
+			} else {
+				assert.NotNil(t, output.Value)
+				assert.Nil(t, output.Error)
+				assert.Equal(t, tt.value, *output.Value)
+			}
+		})
+	}
+}
+
+func TestNewSecretsBackend(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name   string
+		config map[string]interface{}
+		fail   bool
+	}{
+		{
+			name: "valid config with custom path",
+			config: map[string]interface{}{
+				"secrets_path": tmpDir,
+			},
+			fail: false,
+		},
+		{
+			name: "nonexistent directory fails",
+			config: map[string]interface{}{
+				"secrets_path": "/nonexistent/path",
+			},
+			fail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend, err := NewSecretsBackend(tt.config)
+
+			if tt.fail {
+				assert.Error(t, err)
+				assert.Nil(t, backend)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, backend)
+			}
+		})
+	}
+}

--- a/backend/docker/secrets_test.go
+++ b/backend/docker/secrets_test.go
@@ -82,6 +82,11 @@ func TestGetSecretOutput(t *testing.T) {
 			secret: "subdir/secret",
 			fail:   true,
 		},
+		{
+			name:   "backslash in relative name blocked (Windows)",
+			secret: `subdir\secret`,
+			fail:   true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?
supports the many ways docker tries to implement secrets (compose, swarm, mounts)

### Motivation
expand containerization support for secrets

### Additional Notes
secrets in docker are really just mounted files. docker swarm supports the `secret` command which maintains secrets in a raft log, however the secret is also a mounted file. 
- the customer using docker needs to properly have file permissions setup so that the agent/sgc can read the "secrets" 
- https://docs.docker.com/compose/how-tos/use-secrets/
- https://docs.docker.com/engine/swarm/secrets/

### Possible Drawbacks / Trade-offs
- no binary size increase
- docker supports an API however it does not allow for [secret reads](https://docs.docker.com/reference/api/engine/version/v1.52/#tag/Secret/operation/SecretInspect)

### Describe how to test/QA your changes
run the following test script which tests regular `docker` secrets, secrets in `docker compose`, and secrets in `docker swarm`
- `touch docker-test.sh`
- `chmod +x docker-test.sh`
```
#!/bin/bash

FAILED=0

echo ">>> building"
GOOS=linux GOARCH=amd64 go build -o datadog-secret-backend
echo ""

echo ">>> docker run"
mkdir -p test-secrets
echo "docker-run-key" > test-secrets/api_key

OUTPUT=$(docker run --rm \
  -v "$(pwd)/datadog-secret-backend:/app:ro" \
  -v "$(pwd)/test-secrets/api_key:/run/secrets/api_key:ro" \
  alpine:latest \
  sh -c 'echo "{\"secrets\":[\"api_key\"],\"version\":\"1.0\",\"type\":\"docker.secrets\",\"config\":{}}" | /app' 2>&1)

rm -rf test-secrets

echo "$OUTPUT"

if echo "$OUTPUT" | grep -q '"value":"docker-run-key"'; then
    echo ">>> pass"
else
    echo ">>> fail"
    FAILED=1
fi
echo ""

echo ">>> docker compose"
mkdir -p test-secrets
echo "compose-key" > test-secrets/api_key

cat > docker-compose.yml <<'EOF'
services:
  test:
    image: alpine
    volumes:
      - ./datadog-secret-backend:/app:ro
    secrets:
      - api_key
    command: sh -c 'echo "{\"secrets\":[\"api_key\"],\"version\":\"1.0\",\"type\":\"docker.secrets\",\"config\":{}}" | /app'
secrets:
  api_key:
    file: ./test-secrets/api_key
EOF

OUTPUT=$(docker compose up --abort-on-container-exit 2>&1)
docker compose down -v > /dev/null 2>&1
rm -rf test-secrets docker-compose.yml

echo "$OUTPUT" | grep -o '{"api_key":{.*}}'

if echo "$OUTPUT" | grep -q '"value":"compose-key"'; then
    echo ">>> pass"
else
    echo ">>> fail"
    FAILED=1
fi
echo ""

echo ">>> docker swarm"
docker swarm leave --force 2>/dev/null || true
docker swarm init > /dev/null 2>&1

echo "swarm-key" | docker secret create api_key - > /dev/null 2>&1

docker build -t test-backend -f - . > /dev/null 2>&1 <<'EOF'
FROM alpine
COPY datadog-secret-backend /app
CMD ["sleep", "3600"]
EOF

docker service create --name test --secret api_key test-backend > /dev/null 2>&1
sleep 8

CONTAINER=$(docker ps --filter "label=com.docker.swarm.service.name=test" --format "{{.ID}}" | head -1)
OUTPUT=$(docker exec "$CONTAINER" sh -c 'echo "{\"secrets\":[\"api_key\"],\"version\":\"1.0\",\"type\":\"docker.secrets\",\"config\":{}}" | /app' 2>&1)

docker service rm test > /dev/null 2>&1
docker secret rm api_key > /dev/null 2>&1
docker swarm leave --force > /dev/null 2>&1

echo "$OUTPUT"

if echo "$OUTPUT" | grep -q '"value":"swarm-key"'; then
    echo ">>> pass"
else
    echo ">>> fail"
    FAILED=1
fi
echo ""

if [ $FAILED -eq 1 ]; then
    echo ">>> some tests failed"
    exit 1
else
    echo ">>> all tests passed"
fi
```