### PR TITLE
[AGENTCFG-401] Allowing for implicit Vault authentication to be set as a config option or an env var

### DIFF
--- a/backend/hashicorp/vault_test.go
+++ b/backend/hashicorp/vault_test.go
@@ -781,3 +781,107 @@ func TestVaultBackend_ErrorHandling(t *testing.T) {
 		})
 	}
 }
+
+func TestNewAuthenticationFromBackendConfig_ImplicitAuth(t *testing.T) {
+	client, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+
+	tests := map[string]struct {
+		sessionConfig VaultSessionBackendConfig
+		envValue      string
+	}{
+		"implicit auth from config set to 'true'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "true",
+			},
+		},
+		"implicit auth from config set to 'TRUE'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "TRUE",
+			},
+		},
+		"implicit auth from config set to 't'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "t",
+			},
+		},
+		"implicit auth from config set to 'T'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "T",
+			},
+		},
+		"implicit auth from config set to '1'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "1",
+			},
+		},
+		"implicit auth from env set to 'true'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+			},
+			envValue: "true",
+		},
+		"implicit auth from env set to 'TRUE'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+			},
+			envValue: "TRUE",
+		},
+		"implicit auth from env set to 't'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+			},
+			envValue: "t",
+		},
+		"implicit auth from env set to 'T'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+			},
+			envValue: "T",
+		},
+		"implicit auth from env set to '1'": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+			},
+			envValue: "1",
+		},
+		"env var takes precedence over config": {
+			sessionConfig: VaultSessionBackendConfig{
+				VaultAuthType:       "kubernetes",
+				VaultKubernetesRole: "test-role",
+				ImplicitAuth:        "false",
+			},
+			envValue: "true",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tt.envValue != "" {
+				t.Setenv("DD_SECRETS_IMPLICIT_AUTH", tt.envValue)
+			}
+
+			backendConfig := VaultBackendConfig{VaultSession: tt.sessionConfig}
+			auth, token, err := newAuthenticationFromBackendConfig(backendConfig, client)
+
+			assert.NoError(t, err)
+			assert.Nil(t, auth)
+			assert.Equal(t, "implicit auth being used", token)
+		})
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.
-->

### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Copying over the logic of [PPLAT-2526: Add option for implicit Vault authentication](https://github.com/DataDog/datadog-vault-secrets/pull/73) to SGC. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We want to allow a proxy to handle authentication for us.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Unit tests and manual QA. From an internal pod running this binary:
```
echo '{
  "version": "1.1",
  "secrets": ["vault://applications/datadog-agent/shared/agent-api-key-ddstaging.datadoghq.com#/data/value"],
  "type": "hashicorp.vault",
  "config": {
    "vault_session": {
      "vault_auth_type": "kubernetes",
      "implicit_auth": "true"
    }
  }
}' | ./secret-generic-connector
{"vault://applications/datadog-agent/shared/agent-api-key-ddstaging.datadoghq.com#/data/value":{"value":"<redacted>","error":null}}
```