### PR TITLE
add configurable max file read size limit to prevent OOM

### DIFF
--- a/backend/file/json.go
+++ b/backend/file/json.go
@@ -20,7 +20,8 @@ import (
 
 // JSONBackendConfig is the configuration for a JSON backend
 type JSONBackendConfig struct {
-	FilePath string `mapstructure:"file_path"`
+	FilePath        string `mapstructure:"file_path"`
+	MaxFileReadSize int64  `mapstructure:"max_file_read_size"`
 }
 
 // JSONBackend represents backend for JSON file
@@ -37,6 +38,14 @@ func NewJSONBackend(bc map[string]interface{}) (
 	err := mapstructure.Decode(bc, &backendConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
+	}
+
+	if backendConfig.MaxFileReadSize <= 0 {
+		backendConfig.MaxFileReadSize = DefaultMaxFileReadSize
+	}
+
+	if info, err := os.Stat(backendConfig.FilePath); err == nil && info.Size() > backendConfig.MaxFileReadSize {
+		return nil, fmt.Errorf("secret file '%s' exceeds maximum size limit of %d bytes (actual: %d bytes)", backendConfig.FilePath, backendConfig.MaxFileReadSize, info.Size())
 	}
 
 	content, err := os.ReadFile(backendConfig.FilePath)

--- a/backend/file/json.go
+++ b/backend/file/json.go
@@ -41,7 +41,7 @@ func NewJSONBackend(bc map[string]interface{}) (
 	}
 
 	if backendConfig.MaxFileReadSize <= 0 {
-		backendConfig.MaxFileReadSize = DefaultMaxFileReadSize
+		backendConfig.MaxFileReadSize = secret.DefaultMaxFileReadSize
 	}
 
 	if info, err := os.Stat(backendConfig.FilePath); err == nil && info.Size() > backendConfig.MaxFileReadSize {

--- a/backend/file/json_test.go
+++ b/backend/file/json_test.go
@@ -54,54 +54,11 @@ func TestJSONBackend(t *testing.T) {
 func TestJSONBackendMaxFileSize(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Run("default max file size rejects large files", func(t *testing.T) {
-		largeFile := filepath.Join(tmpDir, "large.json")
-		err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
-		assert.NoError(t, err)
+	largeFile := filepath.Join(tmpDir, "large.json")
+	err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
+	assert.NoError(t, err)
 
-		_, err = NewJSONBackend(map[string]interface{}{
-			"file_path": largeFile,
-		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeds maximum size limit")
-	})
-
-	t.Run("custom max file size rejects files exceeding limit", func(t *testing.T) {
-		mediumFile := filepath.Join(tmpDir, "medium.json")
-		err := os.WriteFile(mediumFile, []byte(`{"key": "value"}`), 0644)
-		assert.NoError(t, err)
-
-		_, err = NewJSONBackend(map[string]interface{}{
-			"file_path":          mediumFile,
-			"max_file_read_size": 5,
-		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeds maximum size limit")
-	})
-
-	t.Run("zero max file size uses default", func(t *testing.T) {
-		smallFile := filepath.Join(tmpDir, "small.json")
-		err := os.WriteFile(smallFile, []byte(`{"key": "value"}`), 0644)
-		assert.NoError(t, err)
-
-		backend, err := NewJSONBackend(map[string]interface{}{
-			"file_path":          smallFile,
-			"max_file_read_size": 0,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
-	})
-
-	t.Run("negative max file size uses default", func(t *testing.T) {
-		smallFile := filepath.Join(tmpDir, "small2.json")
-		err := os.WriteFile(smallFile, []byte(`{"key": "value"}`), 0644)
-		assert.NoError(t, err)
-
-		backend, err := NewJSONBackend(map[string]interface{}{
-			"file_path":          smallFile,
-			"max_file_read_size": -1,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
-	})
+	_, err = NewJSONBackend(map[string]interface{}{"file_path": largeFile})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size limit")
 }

--- a/backend/file/json_test.go
+++ b/backend/file/json_test.go
@@ -60,5 +60,5 @@ func TestJSONBackendMaxFileSize(t *testing.T) {
 
 	_, err = NewJSONBackend(map[string]interface{}{"file_path": largeFile})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds default maximum size limit")
+	assert.Contains(t, err.Error(), "exceeds maximum size limit")
 }

--- a/backend/file/json_test.go
+++ b/backend/file/json_test.go
@@ -50,3 +50,58 @@ func TestJSONBackend(t *testing.T) {
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }
+
+func TestJSONBackendMaxFileSize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("default max file size rejects large files", func(t *testing.T) {
+		largeFile := filepath.Join(tmpDir, "large.json")
+		err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
+		assert.NoError(t, err)
+
+		_, err = NewJSONBackend(map[string]interface{}{
+			"file_path": largeFile,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	})
+
+	t.Run("custom max file size rejects files exceeding limit", func(t *testing.T) {
+		mediumFile := filepath.Join(tmpDir, "medium.json")
+		err := os.WriteFile(mediumFile, []byte(`{"key": "value"}`), 0644)
+		assert.NoError(t, err)
+
+		_, err = NewJSONBackend(map[string]interface{}{
+			"file_path":          mediumFile,
+			"max_file_read_size": 5,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	})
+
+	t.Run("zero max file size uses default", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "small.json")
+		err := os.WriteFile(smallFile, []byte(`{"key": "value"}`), 0644)
+		assert.NoError(t, err)
+
+		backend, err := NewJSONBackend(map[string]interface{}{
+			"file_path":          smallFile,
+			"max_file_read_size": 0,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+	})
+
+	t.Run("negative max file size uses default", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "small2.json")
+		err := os.WriteFile(smallFile, []byte(`{"key": "value"}`), 0644)
+		assert.NoError(t, err)
+
+		backend, err := NewJSONBackend(map[string]interface{}{
+			"file_path":          smallFile,
+			"max_file_read_size": -1,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+	})
+}

--- a/backend/file/json_test.go
+++ b/backend/file/json_test.go
@@ -60,5 +60,5 @@ func TestJSONBackendMaxFileSize(t *testing.T) {
 
 	_, err = NewJSONBackend(map[string]interface{}{"file_path": largeFile})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	assert.Contains(t, err.Error(), "exceeds default maximum size limit")
 }

--- a/backend/file/text.go
+++ b/backend/file/text.go
@@ -25,11 +25,6 @@ type TextFileBackendConfig struct {
 	MaxFileReadSize int64  `mapstructure:"max_file_read_size"`
 }
 
-const (
-	// DefaultMaxFileReadSize is the maximum file size (10 MB) that can be read as a secret
-	DefaultMaxFileReadSize = 10 * 1024 * 1024
-)
-
 // TextFileBackend represents backend for individual secret files
 type TextFileBackend struct {
 	Config TextFileBackendConfig
@@ -56,7 +51,7 @@ func NewTextFileBackend(bc map[string]interface{}) (*TextFileBackend, error) {
 	}
 
 	if backendConfig.MaxFileReadSize <= 0 {
-		backendConfig.MaxFileReadSize = DefaultMaxFileReadSize
+		backendConfig.MaxFileReadSize = secret.DefaultMaxFileReadSize
 	}
 
 	return &TextFileBackend{Config: backendConfig}, nil

--- a/backend/file/text_test.go
+++ b/backend/file/text_test.go
@@ -13,6 +13,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-secret-backend/secret"
 )
 
 func TestFileBackendGetSecretOutput(t *testing.T) {
@@ -28,7 +30,7 @@ func TestFileBackendGetSecretOutput(t *testing.T) {
 	backend := &TextFileBackend{
 		Config: TextFileBackendConfig{
 			SecretsPath:     tmpDir,
-			MaxFileReadSize: DefaultMaxFileReadSize,
+			MaxFileReadSize: secret.DefaultMaxFileReadSize,
 		},
 	}
 
@@ -168,7 +170,7 @@ func TestFileBackendMaxFileSize(t *testing.T) {
 			"secrets_path": tmpDir,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
 
 		output := backend.GetSecretOutput(ctx, "small_secret")
 		assert.NotNil(t, output.Value)
@@ -180,7 +182,7 @@ func TestFileBackendMaxFileSize(t *testing.T) {
 			"secrets_path": tmpDir,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
 
 		output := backend.GetSecretOutput(ctx, "large_secret")
 		assert.Nil(t, output.Value)
@@ -221,7 +223,7 @@ func TestFileBackendMaxFileSize(t *testing.T) {
 			"max_file_read_size": 0,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
 	})
 
 	t.Run("negative max file size uses default", func(t *testing.T) {
@@ -230,6 +232,6 @@ func TestFileBackendMaxFileSize(t *testing.T) {
 			"max_file_read_size": -1,
 		})
 		assert.NoError(t, err)
-		assert.Equal(t, int64(DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
 	})
 }

--- a/backend/file/yaml.go
+++ b/backend/file/yaml.go
@@ -20,7 +20,8 @@ import (
 
 // YamlBackendConfig is the configuration for a YAML backend
 type YamlBackendConfig struct {
-	FilePath string `mapstructure:"file_path"`
+	FilePath        string `mapstructure:"file_path"`
+	MaxFileReadSize int64  `mapstructure:"max_file_read_size"`
 }
 
 // YamlBackend represents backend for YAML file
@@ -37,6 +38,14 @@ func NewYAMLBackend(bc map[string]interface{}) (
 	err := mapstructure.Decode(bc, &backendConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to map backend configuration: %s", err)
+	}
+
+	if backendConfig.MaxFileReadSize <= 0 {
+		backendConfig.MaxFileReadSize = DefaultMaxFileReadSize
+	}
+
+	if info, err := os.Stat(backendConfig.FilePath); err == nil && info.Size() > backendConfig.MaxFileReadSize {
+		return nil, fmt.Errorf("secret file '%s' exceeds maximum size limit of %d bytes (actual: %d bytes)", backendConfig.FilePath, backendConfig.MaxFileReadSize, info.Size())
 	}
 
 	content, err := os.ReadFile(backendConfig.FilePath)

--- a/backend/file/yaml.go
+++ b/backend/file/yaml.go
@@ -41,7 +41,7 @@ func NewYAMLBackend(bc map[string]interface{}) (
 	}
 
 	if backendConfig.MaxFileReadSize <= 0 {
-		backendConfig.MaxFileReadSize = DefaultMaxFileReadSize
+		backendConfig.MaxFileReadSize = secret.DefaultMaxFileReadSize
 	}
 
 	if info, err := os.Stat(backendConfig.FilePath); err == nil && info.Size() > backendConfig.MaxFileReadSize {

--- a/backend/file/yaml_test.go
+++ b/backend/file/yaml_test.go
@@ -63,5 +63,5 @@ func TestYAMLBackendMaxFileSize(t *testing.T) {
 
 	_, err = NewYAMLBackend(map[string]interface{}{"file_path": largeFile})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds default maximum size limit")
+	assert.Contains(t, err.Error(), "exceeds maximum size limit")
 }

--- a/backend/file/yaml_test.go
+++ b/backend/file/yaml_test.go
@@ -53,3 +53,58 @@ key2: value2
 	assert.Nil(t, secretOutput.Value)
 	assert.Equal(t, secret.ErrKeyNotFound.Error(), *secretOutput.Error)
 }
+
+func TestYAMLBackendMaxFileSize(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	t.Run("default max file size rejects large files", func(t *testing.T) {
+		largeFile := filepath.Join(tmpDir, "large.yaml")
+		err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
+		assert.NoError(t, err)
+
+		_, err = NewYAMLBackend(map[string]interface{}{
+			"file_path": largeFile,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	})
+
+	t.Run("custom max file size rejects files exceeding limit", func(t *testing.T) {
+		mediumFile := filepath.Join(tmpDir, "medium.yaml")
+		err := os.WriteFile(mediumFile, []byte("key: value"), 0644)
+		assert.NoError(t, err)
+
+		_, err = NewYAMLBackend(map[string]interface{}{
+			"file_path":          mediumFile,
+			"max_file_read_size": 5,
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	})
+
+	t.Run("zero max file size uses default", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "small.yaml")
+		err := os.WriteFile(smallFile, []byte("key: value"), 0644)
+		assert.NoError(t, err)
+
+		backend, err := NewYAMLBackend(map[string]interface{}{
+			"file_path":          smallFile,
+			"max_file_read_size": 0,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+	})
+
+	t.Run("negative max file size uses default", func(t *testing.T) {
+		smallFile := filepath.Join(tmpDir, "small2.yaml")
+		err := os.WriteFile(smallFile, []byte("key: value"), 0644)
+		assert.NoError(t, err)
+
+		backend, err := NewYAMLBackend(map[string]interface{}{
+			"file_path":          smallFile,
+			"max_file_read_size": -1,
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
+	})
+}

--- a/backend/file/yaml_test.go
+++ b/backend/file/yaml_test.go
@@ -57,54 +57,11 @@ key2: value2
 func TestYAMLBackendMaxFileSize(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	t.Run("default max file size rejects large files", func(t *testing.T) {
-		largeFile := filepath.Join(tmpDir, "large.yaml")
-		err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
-		assert.NoError(t, err)
+	largeFile := filepath.Join(tmpDir, "large.yaml")
+	err := os.WriteFile(largeFile, make([]byte, 15*1024*1024), 0644)
+	assert.NoError(t, err)
 
-		_, err = NewYAMLBackend(map[string]interface{}{
-			"file_path": largeFile,
-		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeds maximum size limit")
-	})
-
-	t.Run("custom max file size rejects files exceeding limit", func(t *testing.T) {
-		mediumFile := filepath.Join(tmpDir, "medium.yaml")
-		err := os.WriteFile(mediumFile, []byte("key: value"), 0644)
-		assert.NoError(t, err)
-
-		_, err = NewYAMLBackend(map[string]interface{}{
-			"file_path":          mediumFile,
-			"max_file_read_size": 5,
-		})
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "exceeds maximum size limit")
-	})
-
-	t.Run("zero max file size uses default", func(t *testing.T) {
-		smallFile := filepath.Join(tmpDir, "small.yaml")
-		err := os.WriteFile(smallFile, []byte("key: value"), 0644)
-		assert.NoError(t, err)
-
-		backend, err := NewYAMLBackend(map[string]interface{}{
-			"file_path":          smallFile,
-			"max_file_read_size": 0,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
-	})
-
-	t.Run("negative max file size uses default", func(t *testing.T) {
-		smallFile := filepath.Join(tmpDir, "small2.yaml")
-		err := os.WriteFile(smallFile, []byte("key: value"), 0644)
-		assert.NoError(t, err)
-
-		backend, err := NewYAMLBackend(map[string]interface{}{
-			"file_path":          smallFile,
-			"max_file_read_size": -1,
-		})
-		assert.NoError(t, err)
-		assert.Equal(t, int64(secret.DefaultMaxFileReadSize), backend.Config.MaxFileReadSize)
-	})
+	_, err = NewYAMLBackend(map[string]interface{}{"file_path": largeFile})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size limit")
 }

--- a/backend/file/yaml_test.go
+++ b/backend/file/yaml_test.go
@@ -63,5 +63,5 @@ func TestYAMLBackendMaxFileSize(t *testing.T) {
 
 	_, err = NewYAMLBackend(map[string]interface{}{"file_path": largeFile})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "exceeds maximum size limit")
+	assert.Contains(t, err.Error(), "exceeds default maximum size limit")
 }

--- a/secret/secret.go
+++ b/secret/secret.go
@@ -26,3 +26,8 @@ type Output struct {
 
 // ErrKeyNotFound is returned when the secret key is not found
 var ErrKeyNotFound = errors.New("backend does not provide secret key")
+
+const (
+	// DefaultMaxFileReadSize is the maximum file size (10 MB) that can be read as a secret
+	DefaultMaxFileReadSize = 10 * 1024 * 1024
+)


### PR DESCRIPTION
### What does this PR do?
adds a configurable max read size limit to file backends to prevent any potential OOM issues.

### Motivation
https://github.com/DataDog/datadog-secret-backend/pull/293#discussion_r2622827544

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes