### PR TITLE
update v1 branch readme regarding archival of secret backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # datadog-secret-backend
 
+> [!IMPORTANT]
 > **This repository has been archived and is now read-only.**
 >
 > The `datadog-secret-backend` project has been migrated into the [Datadog Agent monorepo](https://github.com/DataDog/datadog-agent) as `secret-generic-connector`.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,36 @@
 # datadog-secret-backend
 
+> **This repository has been archived and is now read-only.**
+>
+> The `datadog-secret-backend` project has been migrated into the [Datadog Agent monorepo](https://github.com/DataDog/datadog-agent) as `secret-generic-connector`.
+> See the [Datadog Agent Secrets Management documentation](https://docs.datadoghq.com/agent/guide/secrets-management/).
+>
+> - **Agent 7.70+**: The secret backend binary was first bundled inside the Agent. Separate installation of `datadog-secret-backend` is no longer needed -- configure using `secret_backend_type` and `secret_backend_config` in your `datadog.yaml`.
+> - **Agent 7.77.0+**: The source code now lives in the Agent repo and includes FIPS compliance support.
+>
+> **For existing users:** Existing installations of this standalone binary will continue to work with newer Agent. But we strongly recommend upgrading to Agent 7.77.0+ and migrating to `secret_backend_type` configuration to benefit from the latest improvements (new features and CVE fixes from the cloud providers SDK used by this project).
+>
+> **For contributors and developers:**
+> - Source code: [`cmd/secret-generic-connector`](https://github.com/DataDog/datadog-agent/tree/main/cmd/secret-generic-connector)
+> - Issues: [Datadog Agent Issues](https://github.com/DataDog/datadog-agent/issues)
+
+---
+
 [![.github/workflows/release.yaml](https://github.com/DataDog/datadog-secret-backend/actions/workflows/release.yaml/badge.svg)](https://github.com/DataDog/datadog-secret-backend/actions/workflows/release.yaml)
 
 > **datadog-secret-backend** is an implementation of the [Datadog Agent Secrets Management](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux) executable supporting multiple backend secret providers.
 
-**IMPORTANT NOTE**: A new major version, `v1`, of `datadog-secret-backend` has been released with a simplified configuration process and a better integration with the Datadog Agent. This new version is not compatible with the `v0` configuration files. `v0` will continue to be maintained on the `v0` branch of this repository and remains compatible with the Datadog Agent. You can find previous releases of `v0` [here](https://github.com/DataDog/datadog-secret-backend/releases).
+This branch contains `v1` of `datadog-secret-backend`, which introduced a simplified configuration process and tighter integration with the Datadog Agent. It is not compatible with `v0` configuration files.
+The `v1` version provided the following key improvements:
+1. The `datadog-secret-backend` is shipped within the Datadog Agent starting with version 7.69.
+2. The backend is configured directly within the configuration file of the Datadog Agent rather than a dedicated external file.
+3. The type of backend is configured directly from the configuration file of the Datadog Agent. There is no need to prefix your secret with the `backendID`.
 
-The `v1` version comes with the following key improvements:
-1. The `datadog-secret-backend` is now shipped within the Datadog Agent starting with version 7.69.
-2. The backend is now configured directly within the configuration file of the Datadog Agent rather than a dedicated external file.
-3. The type of backend is now configured directly from the configuration file of the Datadog Agent. There is no need to prefix your secret with the `backendID`.
-More information on how to use the `v1` can be found [here](https://docs.datadoghq.com/agent/configuration/secrets-management).
+More information can be found in the [Datadog Secrets Management documentation](https://docs.datadoghq.com/agent/configuration/secrets-management).
 
 ## Supported Backends
 
-| Backend | Provider | Description |
-| :-- | :-- | :-- |
-| [aws.secrets](docs/aws/secrets.md) | [aws](docs/aws/README.md) | Datadog secrets in AWS Secrets Manager |
-| [aws.ssm](docs/aws/ssm.md) | [aws](docs/aws/README.md) | Datadog secrets in AWS Systems Manager Parameter Store |
-| [azure.keyvault](docs/azure/keyvault.md) | [azure](docs/azure/README.md) | Datadog secrets in Azure Key Vault |
-| [hashicorp.vault](docs/hashicorp/vault.md) | [hashicorp](docs/hashicorp/README.md) | Datadog secrets in Hashicorp Vault |
-| [file.json](docs/file/json.md) | [file](docs/file/README.md) | Datadog secrets in local JSON files|
-| [file.yaml](docs/file/yaml.md) | [file](docs/file/README.md) | Datadog secrets in local YAML files|
-
-## Usage
-
-Reference each supported backend type's documentation on specific usage examples and configuration options.
+For the full list of supported backends, configuration options, and usage examples, see the [Datadog Secrets Management documentation](https://docs.datadoghq.com/agent/configuration/secrets-management).
 
 ## License
 


### PR DESCRIPTION
### What does this PR do?
Updates the readme of the v1 branch with information regarding the archival and moving of the secret-backend

### Motivation
move towards the datadog-agent repo

### Additional Notes
