### PR TITLE
bump go 1.25.7

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.6'
+        go-version: '1.25.7'
 
     - name: Build
       run: go build -v ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: [1.25.6]
+        go: [1.25.7]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,7 +27,7 @@ jobs:
     - uses: wangyoucao577/go-release-action@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        goversion: 1.25.6
+        goversion: 1.25.7
         goos: ${{ matrix.goos }}
         goarch: ${{ matrix.goarch }}
         asset_name: datadog-secret-backend-${{ matrix.goos }}-${{ matrix.goarch }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-secret-backend
 
-go 1.25.6
+go 1.25.7
 
 replace (
 	github.com/DataDog/datadog-secret-backend/backend => ./backend


### PR DESCRIPTION
### What does this PR do?
bumps go to 1.25.7 for security benefits

### Motivation
potential CVE fixes

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes